### PR TITLE
Fix PlayerStatsPanel throwing an error if no description was specified on class initialization 

### DIFF
--- a/ScaleformUI_Csharp/LobbyMenu/Panels/PlayerStatsPanel.cs
+++ b/ScaleformUI_Csharp/LobbyMenu/Panels/PlayerStatsPanel.cs
@@ -88,6 +88,7 @@ namespace ScaleformUI.LobbyMenu
         {
             this.title = title;
             this.titleColor = titleColor;
+            this.description = string.Empty;
             RankInfo = new(this);
             Items = new();
         }


### PR DESCRIPTION
This single line PR fixes an error that was thrown when creating a PlayerStatsPanel if no description was specified. This will now allow you to create a PlayerStatsPanel with no description without breaking. Has been tested locally.