### PR TITLE
Tab change works in any focus level

### DIFF
--- a/ScaleformUI_Lua/src/PauseMenu/TabView.lua
+++ b/ScaleformUI_Lua/src/PauseMenu/TabView.lua
@@ -887,16 +887,18 @@ function TabView:ProcessControl()
     end
     if (IsControlJustPressed(2, 205)) then
         Citizen.CreateThread(function()
-            if (self:FocusLevel() == 0) then
-                self:GoLeft()
+            if (self:FocusLevel() ~= 0) then
+                self:FocusLevel(0)
             end
+            self:GoLeft()
         end)
     end
     if (IsControlJustPressed(2, 206)) then
         Citizen.CreateThread(function()
-            if (self:FocusLevel() == 0) then
-                self:GoRight()
+            if (self:FocusLevel() ~= 0) then
+                self:FocusLevel(0)
             end
+            self:GoRight()
         end)
     end
     if (IsControlJustPressed(2, 201)) then


### PR DESCRIPTION
Now you can use Q/E or LB/RB to change tabs even if you are not on focus 0 (as it should be)