### PR TITLE
Fix UIMenuGridPanel:CirclePosition

### DIFF
--- a/ScaleformUI_Lua/src/base/UIMenu.lua
+++ b/ScaleformUI_Lua/src/base/UIMenu.lua
@@ -607,7 +607,7 @@ function UIMenu:BuildUpMenuAsync()
                     elseif pSubType == "UIMenuPercentagePanel" then
                         ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", false, it - 1, 1, panel.Title, panel.Min, panel.Max, panel.Percentage)
                     elseif pSubType == "UIMenuGridPanel" then
-                        ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", false, it - 1, 2, panel.TopLabel, panel.RightLabel, panel.LeftLabel, panel.BottomLabel, panel.CirclePosition.x, panel.CirclePosition.y, true, panel.GridType)
+                        ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", false, it - 1, 2, panel.TopLabel, panel.RightLabel, panel.LeftLabel, panel.BottomLabel, panel._CirclePosition.x, panel._CirclePosition.y, true, panel.GridType)
                     elseif pSubType == "UIMenuStatisticsPanel" then
                         ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", false, it - 1, 3)
                         if #panel.Items then
@@ -722,7 +722,7 @@ function UIMenu:BuildUpMenuSync()
                     elseif pSubType == "UIMenuPercentagePanel" then
                         ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", false, it - 1, 1, panel.Title, panel.Min, panel.Max, panel.Percentage)
                     elseif pSubType == "UIMenuGridPanel" then
-                        ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", false, it - 1, 2, panel.TopLabel, panel.RightLabel, panel.LeftLabel, panel.BottomLabel, panel.CirclePosition.x, panel.CirclePosition.y, true, panel.GridType)
+                        ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", false, it - 1, 2, panel.TopLabel, panel.RightLabel, panel.LeftLabel, panel.BottomLabel, panel._CirclePosition.x, panel._CirclePosition.y, true, panel.GridType)
                     elseif pSubType == "UIMenuStatisticsPanel" then
                         ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", false, it - 1, 3)
                         if #panel.Items then
@@ -1264,9 +1264,9 @@ function UIMenu:ProcessMouse()
             local panel_type, panel_subtype = panel()
     
             if panel_subtype == "UIMenuGridPanel" then
-                panel.CirclePosition = vector2(tonumber(split[2]), tonumber(split[3]))
-                self.OnGridPanelChanged(panel.ParentItem, panel, panel.CirclePosition)
-                panel.OnGridPanelChanged(panel.ParentItem, panel, panel.CirclePosition)
+                panel._CirclePosition = vector2(tonumber(split[2]), tonumber(split[3]))
+                self.OnGridPanelChanged(panel.ParentItem, panel, panel._CirclePosition)
+                panel.OnGridPanelChanged(panel.ParentItem, panel, panel._CirclePosition)
             elseif panel_subtype == "UIMenuPercentagePanel" then
                 panel.Percentage = tonumber(split[2])
                 self:OnPercentagePanelChanged(panel.ParentItem, panel, panel.Percentage)

--- a/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
+++ b/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
@@ -36,7 +36,7 @@ function UIMenuGridPanel:SetCirclePosition(position)
 		if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
 			local it = IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)
 			local van = IndexOf(self.ParentItem.Panels, self)
-			ScaleformUI.Scaleforms._ui:CallFunction("SET_GRID_PANEL_VALUE_RETURN_VALUE", false, it, van, position.x, position.y)
+			ScaleformUI.Scaleforms._ui:CallFunction("SET_GRID_PANEL_VALUE_RETURN_VALUE", false, it-1, van-1, position.x, position.y)
 		end
 	else
 		return self.CirclePosition

--- a/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
+++ b/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
@@ -30,7 +30,7 @@ function UIMenuGridPanel:SetParentItem(Item) -- required
 	end
 end
 
-function UIMenuGridPanel:CirclePosition(position)
+function UIMenuGridPanel:SetCirclePosition(position)
 	if position ~= nil then
 		self.CirclePosition = position
 		if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then

--- a/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
+++ b/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
@@ -30,7 +30,7 @@ function UIMenuGridPanel:SetParentItem(Item) -- required
 	end
 end
 
-function UIMenuGridPanel:SetCirclePosition(position)
+function UIMenuGridPanel:CirclePosition(position)
 	if position ~= nil then
 		self.CirclePosition = position
 		if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then

--- a/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
+++ b/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
@@ -23,7 +23,7 @@ end
 ---SetParentItem
 ---@param Item table
 function UIMenuGridPanel:SetParentItem(Item) -- required
-	if not Item() == nil then
+	if Item() ~= nil then
 		self.ParentItem = Item
 	else
 		return self.ParentItem

--- a/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
+++ b/ScaleformUI_Lua/src/panels/UIMenuGridPanel.lua
@@ -12,7 +12,7 @@ function UIMenuGridPanel.New(topText, leftText, rightText, bottomText, circlePos
 		RightLabel = leftText or "RIGHT",
 		LeftLabel = rightText or "LEFT",
 		BottomLabel = bottomText or "DOWN",
-		CirclePosition = circlePosition or vector2(0.5, 0.5),
+		_CirclePosition = circlePosition or vector2(0.5, 0.5),
 		GridType = gridType or 0,
 		ParentItem = nil, -- required
 		OnGridPanelChanged = function(item, panel, newindex) end
@@ -32,13 +32,13 @@ end
 
 function UIMenuGridPanel:CirclePosition(position)
 	if position ~= nil then
-		self.CirclePosition = position
+		self._CirclePosition = position
 		if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
 			local it = IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)
 			local van = IndexOf(self.ParentItem.Panels, self)
 			ScaleformUI.Scaleforms._ui:CallFunction("SET_GRID_PANEL_VALUE_RETURN_VALUE", false, it-1, van-1, position.x, position.y)
 		end
 	else
-		return self.CirclePosition
+		return self._CirclePosition
 	end
 end


### PR DESCRIPTION
UIMenuGridPanel would always return the current CirclePosition instead of setting it when a value is parsed, because the Variable Name of the object is the same as the function. (noticed after 4 hours of debugging 🔥)

UIMenuGridPanel:CirclePosition has been changed to UIMenuGridPanel:SetCirclePosition
(would need to be updated in Wiki aswell)