### PR TITLE
feat(rankbar): add rank bar

### DIFF
--- a/ScaleformUI_Csharp/ScaleformUI.csproj
+++ b/ScaleformUI_Csharp/ScaleformUI.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scaleforms\MediumMessage\MediumMessage.cs" />
     <Compile Include="Scaleforms\MissionSelector\MissionSelectorHandler.cs" />
+    <Compile Include="Scaleforms\RankBar\RankBarHandler.cs" />
     <Compile Include="Scaleforms\ScaleformUI\ScaleformUI.cs" />
     <Compile Include="Scaleforms\PauseMenu\PauseMenuScaleform.cs" />
     <Compile Include="Scaleforms\PopupWarning\PopupWarning.cs" />

--- a/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
@@ -1,0 +1,74 @@
+﻿using CitizenFX.Core;
+using CitizenFX.Core.Native;
+
+namespace ScaleformUI.Scaleforms.RankBar
+{
+    public class RankBarHandler
+    {
+        private const int HUD_COMPONENT_ID = 19;
+        public Scaleform _sc;
+
+        private int _limitStart = 0;
+        private int _limitEnd = 0;
+        private int _previousValue = 0;
+        private int _currentValue = 0;
+        private int _currentRank = 1;
+
+        private HudColor _rankBarColor = HudColor.HUD_COLOUR_FREEMODE;
+
+        /// <summary>
+        /// Set the color of the Rank Bar when displayed
+        /// </summary>
+        public HudColor Color
+        {
+            get => _rankBarColor;
+            set
+            {
+                _rankBarColor = value;
+            }
+        }
+
+        public int LimitStart { get => _limitStart; set => _limitStart = value; }
+        public int LimitEnd { get => _limitEnd; set => _limitEnd = value; }
+        public int PreviousValue { get => _previousValue; set => _previousValue = value; }
+        public int CurrentValue { get => _currentValue; set => _currentValue = value; }
+        public int CurrentRank { get => _currentRank; set => _currentRank = value; }
+
+        public RankBarHandler() { }
+
+        public async void SetScores(int limitStart, int limitEnd, int previousValue, int currentValue, int currentRank)
+        {
+            API.RequestHudScaleform(HUD_COMPONENT_ID);
+            while (!API.HasHudScaleformLoaded(HUD_COMPONENT_ID))
+            {
+                await BaseScript.Delay(0);
+            }
+
+            // Color has to be set else it will be white by default
+            API.BeginScaleformMovieMethodHudComponent(HUD_COMPONENT_ID, "SET_COLOUR");
+            API.PushScaleformMovieFunctionParameterInt((int)_rankBarColor);
+            API.EndScaleformMovieMethodReturn();
+
+            _limitStart = limitStart;
+            _limitEnd = limitEnd;
+            _previousValue = previousValue;
+            _currentValue = currentValue;
+            _currentRank = currentRank;
+
+            // this will set an update the score
+            API.BeginScaleformMovieMethodHudComponent(HUD_COMPONENT_ID, "SET_RANK_SCORES");
+            API.PushScaleformMovieFunctionParameterInt(limitStart);
+            API.PushScaleformMovieFunctionParameterInt(limitEnd);
+            API.PushScaleformMovieFunctionParameterInt(previousValue);
+            API.PushScaleformMovieFunctionParameterInt(currentValue);
+            API.PushScaleformMovieFunctionParameterInt(currentRank);
+            API.PushScaleformMovieFunctionParameterInt(100);
+            API.EndScaleformMovieMethodReturn();
+        }
+
+        public void Show()
+        {
+            SetScores(_limitStart, _limitEnd, _previousValue, _currentValue, _currentRank);
+        }
+    }
+}

--- a/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
@@ -17,7 +17,6 @@ namespace ScaleformUI.Scaleforms.RankBar
         private int _nextRank = 2;
 
         private HudColor _rankBarColor = HudColor.HUD_COLOUR_FREEMODE;
-        private HudColor _rankBarColorTwo = HudColor.HUD_COLOUR_FREEMODE_DARK;
 
         /// <summary>
         /// Set the color of the Rank Bar when displayed
@@ -28,14 +27,6 @@ namespace ScaleformUI.Scaleforms.RankBar
             set
             {
                 _rankBarColor = value;
-            }
-        }
-        public HudColor ColorTwo
-        {
-            get => _rankBarColorTwo;
-            set
-            {
-                _rankBarColorTwo = value;
             }
         }
 
@@ -75,7 +66,6 @@ namespace ScaleformUI.Scaleforms.RankBar
             // Color has to be set else it will be white by default
             API.BeginScaleformMovieMethodHudComponent(HUD_COMPONENT_ID, "SET_COLOUR");
             API.PushScaleformMovieFunctionParameterInt((int)_rankBarColor);
-            API.PushScaleformMovieFunctionParameterInt((int)_rankBarColorTwo);
             API.EndScaleformMovieMethod();
 
             _limitStart = limitStart;

--- a/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
@@ -1,20 +1,23 @@
 ﻿using CitizenFX.Core;
 using CitizenFX.Core.Native;
+using System.Threading.Tasks;
+using System;
 
 namespace ScaleformUI.Scaleforms.RankBar
 {
     public class RankBarHandler
     {
         private const int HUD_COMPONENT_ID = 19;
-        public Scaleform _sc;
 
         private int _limitStart = 0;
         private int _limitEnd = 0;
         private int _previousValue = 0;
         private int _currentValue = 0;
         private int _currentRank = 1;
+        private int _nextRank = 2;
 
         private HudColor _rankBarColor = HudColor.HUD_COLOUR_FREEMODE;
+        private HudColor _rankBarColorTwo = HudColor.HUD_COLOUR_FREEMODE_DARK;
 
         /// <summary>
         /// Set the color of the Rank Bar when displayed
@@ -27,27 +30,53 @@ namespace ScaleformUI.Scaleforms.RankBar
                 _rankBarColor = value;
             }
         }
+        public HudColor ColorTwo
+        {
+            get => _rankBarColorTwo;
+            set
+            {
+                _rankBarColorTwo = value;
+            }
+        }
 
         public int LimitStart { get => _limitStart; set => _limitStart = value; }
         public int LimitEnd { get => _limitEnd; set => _limitEnd = value; }
         public int PreviousValue { get => _previousValue; set => _previousValue = value; }
         public int CurrentValue { get => _currentValue; set => _currentValue = value; }
         public int CurrentRank { get => _currentRank; set => _currentRank = value; }
+        public int NextRank { get => _nextRank; set => _nextRank = value; }
 
         public RankBarHandler() { }
 
-        public async void SetScores(int limitStart, int limitEnd, int previousValue, int currentValue, int currentRank)
+        public async Task Load()
         {
+            var timeout = 1000;
+            var start = DateTime.Now;
+
             API.RequestHudScaleform(HUD_COMPONENT_ID);
-            while (!API.HasHudScaleformLoaded(HUD_COMPONENT_ID))
+            while (!API.HasHudScaleformLoaded(HUD_COMPONENT_ID) && DateTime.Now.Subtract(start).TotalMilliseconds < timeout)
             {
                 await BaseScript.Delay(0);
             }
+        }
+
+        /// <summary>
+        /// Shows the rank bar
+        /// </summary>
+        /// <param name="limitStart">Floor value of experience e.g. 0</param>
+        /// <param name="limitEnd">Ceiling value of experience e.g. 800</param>
+        /// <param name="previousValue">Previous Experience value </param>
+        /// <param name="currentValue">New Experience value</param>
+        /// <param name="currentRank">Current rank</param>
+        public async void SetScores(int limitStart, int limitEnd, int previousValue, int currentValue, int currentRank)
+        {
+            await Load();
 
             // Color has to be set else it will be white by default
             API.BeginScaleformMovieMethodHudComponent(HUD_COMPONENT_ID, "SET_COLOUR");
             API.PushScaleformMovieFunctionParameterInt((int)_rankBarColor);
-            API.EndScaleformMovieMethodReturn();
+            API.PushScaleformMovieFunctionParameterInt((int)_rankBarColorTwo);
+            API.EndScaleformMovieMethod();
 
             _limitStart = limitStart;
             _limitEnd = limitEnd;
@@ -63,12 +92,32 @@ namespace ScaleformUI.Scaleforms.RankBar
             API.PushScaleformMovieFunctionParameterInt(currentValue);
             API.PushScaleformMovieFunctionParameterInt(currentRank);
             API.PushScaleformMovieFunctionParameterInt(100);
-            API.EndScaleformMovieMethodReturn();
+            API.EndScaleformMovieMethod();
         }
 
-        public void Show()
+        public void Remove()
         {
-            SetScores(_limitStart, _limitEnd, _previousValue, _currentValue, _currentRank);
+            if (API.HasHudScaleformLoaded(HUD_COMPONENT_ID))
+            {
+                API.BeginScaleformScriptHudMovieMethod(HUD_COMPONENT_ID, "REMOVE");
+                API.EndScaleformMovieMethod();
+            }
+        }
+
+        public async void OverrideAnimationSpeed(int speed = 1000)
+        {
+            await Load();
+            API.BeginScaleformScriptHudMovieMethod(HUD_COMPONENT_ID, "OVERRIDE_ANIMATION_SPEED");
+            API.PushScaleformMovieFunctionParameterInt(speed);
+            API.EndScaleformMovieMethod();
+        }
+
+        public async void OverrideOnscreenDuration(int duration = 4000)
+        {
+            await Load();
+            API.BeginScaleformScriptHudMovieMethod(HUD_COMPONENT_ID, "OVERRIDE_ONSCREEN_DURATION");
+            API.PushScaleformMovieFunctionParameterInt(duration);
+            API.EndScaleformMovieMethod();
         }
     }
 }

--- a/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
+++ b/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
@@ -1,5 +1,6 @@
 ﻿using CitizenFX.Core;
 using CitizenFX.Core.Native;
+using ScaleformUI.Scaleforms.RankBar;
 using System;
 using System.Threading.Tasks;
 
@@ -15,6 +16,7 @@ namespace ScaleformUI
         public static PlayerListHandler PlayerListInstance { get; set; }
         public static MissionSelectorHandler JobMissionSelection { get; set; }
         public static BigFeedHandler BigFeed { get; set; }
+        public static RankBarHandler RankBarInstance { get; set; }
 
         internal static Scaleform _ui { get; set; }
         public ScaleformUI()
@@ -29,6 +31,7 @@ namespace ScaleformUI
             _ui = new("scaleformui");
             InstructionalButtons = new();
             InstructionalButtons.Load();
+            RankBarInstance = new();
             Tick += ScaleformUIThread_Tick;
 
             EventHandlers["onResourceStop"] += new Action<string>((resName) =>


### PR DESCRIPTION
Currently able to show the rank bar with values but I would like to deal with the issue of it resetting and flashing on updates so I will be researching later this weekend, already past my current sleep time.

In relation to #38 

Example is just a call to the current SetScores method.
e.g. `ScaleformUI.RankBarInstance.SetScores(0, 800, 20, 20, 1);`

You can set the following;
- Bar Color (example: 116 HUD_COLOUR_FREEMODE)
- Current Rank (example: 1)
- Level Floor (example: 0)
- Level Ceiling (example: 800)
- Previous Value (example: 20)
- Current Value (example: previous value + 200 - this is to show the white bar for value increase in the example)

This allows the implementer to add their own leveling system in, but if an example is required, let me know.

Video to show current "flashing" issue.
https://user-images.githubusercontent.com/6077794/206822679-4e57a618-a4d9-478b-9519-bf26ea7cf67a.mp4

