### PR TITLE
feat(scaleform): add countdown and rankbar in lua

### DIFF
--- a/ScaleformUI_Csharp/Scaleforms/Countdown/CountdownHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Countdown/CountdownHandler.cs
@@ -42,15 +42,13 @@ namespace ScaleformUI.Scaleforms.Countdown
 
             while (number >= 0)
             {
-                if ((API.GetGameTimer() - gameTime) < 1000)
-                    await BaseScript.Delay(0);
-                else
+                await BaseScript.Delay(0);
+                if ((API.GetGameTimer() - gameTime) > 1000)
                 {
                     API.PlaySoundFrontend(-1, countdownAudioName, countdownAudioRef, true);
                     gameTime = API.GetGameTimer();
                     ShowMessage(number, r, g, b);
                     number--;
-                    await BaseScript.Delay(0);
                 }
             }
 

--- a/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
@@ -9,13 +9,6 @@ namespace ScaleformUI.Scaleforms.RankBar
     {
         private const int HUD_COMPONENT_ID = 19;
 
-        private int _limitStart = 0;
-        private int _limitEnd = 0;
-        private int _previousValue = 0;
-        private int _currentValue = 0;
-        private int _currentRank = 1;
-        private int _nextRank = 2;
-
         private HudColor _rankBarColor = HudColor.HUD_COLOUR_FREEMODE;
 
         /// <summary>
@@ -29,13 +22,6 @@ namespace ScaleformUI.Scaleforms.RankBar
                 _rankBarColor = value;
             }
         }
-
-        public int LimitStart { get => _limitStart; set => _limitStart = value; }
-        public int LimitEnd { get => _limitEnd; set => _limitEnd = value; }
-        public int PreviousValue { get => _previousValue; set => _previousValue = value; }
-        public int CurrentValue { get => _currentValue; set => _currentValue = value; }
-        public int CurrentRank { get => _currentRank; set => _currentRank = value; }
-        public int NextRank { get => _nextRank; set => _nextRank = value; }
 
         public RankBarHandler() { }
 
@@ -67,12 +53,6 @@ namespace ScaleformUI.Scaleforms.RankBar
             API.BeginScaleformMovieMethodHudComponent(HUD_COMPONENT_ID, "SET_COLOUR");
             API.PushScaleformMovieFunctionParameterInt((int)_rankBarColor);
             API.EndScaleformMovieMethod();
-
-            _limitStart = limitStart;
-            _limitEnd = limitEnd;
-            _previousValue = previousValue;
-            _currentValue = currentValue;
-            _currentRank = currentRank;
 
             // this will set an update the score
             API.BeginScaleformMovieMethodHudComponent(HUD_COMPONENT_ID, "SET_RANK_SCORES");

--- a/ScaleformUI_Lua/src/scaleforms/Countdown/CountdownHandler.lua
+++ b/ScaleformUI_Lua/src/scaleforms/Countdown/CountdownHandler.lua
@@ -1,0 +1,102 @@
+CountdownHandler = {}
+
+local m = {}
+m = setmetatable({}, m)
+
+m.__call = function()
+    return true
+end
+m.__index = m
+
+local _r;
+local _g;
+local _b;
+local _a;
+
+function CountdownHandler.New()
+    local _sc = 0
+    local _start = 0
+    local _timer = 0
+    local data = {_sc = _sc, _start = _start, _timer = _timer}
+    return setmetatable(data, m)
+end
+
+function m:Load()
+    local p = promise.new()
+
+    if self._sc ~= 0 then
+        p:resolve()
+        return p
+    end
+
+    RequestScriptAudioBank("HUD_321_GO", false);
+
+    self._sc = Scaleform.Request("COUNTDOWN")
+    local timeout = 1000
+    local start = GetGameTimer()
+    while not self._sc:IsLoaded() and GetGameTimer() - start < timeout do Citizen.Wait(0) end
+
+    if self._sc:IsLoaded() then
+        p:resolve()
+    else
+        p:reject()
+    end
+
+    return p
+end
+
+function m:Dispose(force)
+    self._sc:Dispose()
+    self._sc = 0
+end
+
+function m:Update()
+    self._sc:Render2D()
+end
+
+function m:ShowMessage(message)
+    self._sc:CallFunction("SET_MESSAGE", false, message, _r, _g, _b, true);
+    self._sc:CallFunction("FADE_MP", false, message, _r, _g, _b);
+end
+
+function m:Start(number, hudColour, countdownAudioName, countdownAudioRef, goAudioName, goAudioRef)
+    local p = promise.new()
+    
+    if number == nil then number = 3 end
+    if hudColour == nil then hudColour = 18 end
+    if countdownAudioName == nil then countdownAudioName = "321" end
+    if countdownAudioRef == nil then countdownAudioRef = "Car_Club_Races_Pursuit_Series_Sounds" end
+    if goAudioName == nil then goAudioName = "Go" end
+    if goAudioRef == nil then goAudioRef = "Car_Club_Races_Pursuit_Series_Sounds" end
+    
+    self:Load():next(function()
+
+        _r, _g, _b, _a = GetHudColour(hudColour)
+        
+        local gameTime = GetGameTimer()
+
+        while number >= 0 do
+            Wait(0)
+
+            if GetGameTimer() - gameTime > 1000 then
+                PlaySoundFrontend(-1, countdownAudioName, countdownAudioRef, true);
+                self:ShowMessage(number)
+                number = number - 1
+                gameTime = GetGameTimer()
+            end
+        end
+
+        PlaySoundFrontend(-1, goAudioName, goAudioRef, true);
+        self:ShowMessage("CNTDWN_GO")
+        p:resolve()
+        
+        if GetGameTimer() - gameTime > 1000 then
+            self:Dispose()
+        end
+    end, function()
+        error("Failed to load countdown scaleform")
+        p:reject()
+    end)
+
+    return p
+end

--- a/ScaleformUI_Lua/src/scaleforms/Rankbar/RankbarHandler.lua
+++ b/ScaleformUI_Lua/src/scaleforms/Rankbar/RankbarHandler.lua
@@ -1,0 +1,83 @@
+RankbarHandler = {}
+
+local m = {}
+m = setmetatable({}, m)
+
+m.__call = function()
+    return true
+end
+m.__index = m
+
+local HUD_COMPONENT_ID = 19
+local _rankBarColor = 116
+
+function RankbarHandler.New()
+    local data = { }
+    return setmetatable(data, m)
+end
+
+function m:Load()
+    local p = promise.new()
+
+    if HasScaleformScriptHudMovieLoaded(HUD_COMPONENT_ID) then 
+        p:resolve()
+        return p
+    end
+
+    RequestScaleformScriptHudMovie(HUD_COMPONENT_ID)
+    local timeout = 1000
+    local start = GetGameTimer()
+    while not HasScaleformScriptHudMovieLoaded(HUD_COMPONENT_ID) and GetGameTimer() - start < timeout do Citizen.Wait(0) end
+
+    if HasScaleformScriptHudMovieLoaded(HUD_COMPONENT_ID) then
+        p:resolve()
+    else
+        p:reject()
+    end
+
+    return p
+end
+
+function m:SetScores(limitStart, limitEnd, previousValue, currentValue, currentRank)
+    self:Load():next(function()
+        BeginScaleformScriptHudMovieMethod(HUD_COMPONENT_ID, "SET_COLOUR")
+        ScaleformMovieMethodAddParamInt(_rankBarColor)
+        EndScaleformMovieMethod()
+    
+        BeginScaleformScriptHudMovieMethod(HUD_COMPONENT_ID, "SET_RANK_SCORES")
+        ScaleformMovieMethodAddParamInt(limitStart)
+        ScaleformMovieMethodAddParamInt(limitEnd)
+        ScaleformMovieMethodAddParamInt(previousValue)
+        ScaleformMovieMethodAddParamInt(currentValue)
+        ScaleformMovieMethodAddParamInt(currentRank)
+        EndScaleformMovieMethod()
+    end)
+    
+end
+
+function m:SetColour(rankBarColor)
+    _rankBarColor = rankBarColor
+end
+
+function m:Remove()
+    if HasScaleformScriptHudMovieLoaded(HUD_COMPONENT_ID) then
+        BeginScaleformScriptHudMovieMethod(HUD_COMPONENT_ID, "REMOVE");
+        EndScaleformMovieMethod();
+    end
+end
+
+function m:OverrideAnimationSpeed(speed)
+    self:Load():next(function()
+        BeginScaleformScriptHudMovieMethod(HUD_COMPONENT_ID, "OVERRIDE_ANIMATION_SPEED");
+        ScaleformMovieMethodAddParamInt(speed);
+        EndScaleformMovieMethod();
+    end)
+end
+
+function m:OverrideOnscreenDuration(duration)
+    self:Load():next(function()
+        BeginScaleformScriptHudMovieMethod(HUD_COMPONENT_ID, "OVERRIDE_ONSCREEN_DURATION");
+        ScaleformMovieMethodAddParamInt(duration);
+        EndScaleformMovieMethod();
+    end)
+end

--- a/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
@@ -10,6 +10,8 @@ ScaleformUI.Scaleforms.BigMessageInstance = nil
 ScaleformUI.Scaleforms.Warning = nil
 ScaleformUI.Scaleforms.PlayerListInstance = nil
 ScaleformUI.Scaleforms.JobMissionSelector = nil
+ScaleformUI.Scaleforms.RankbarHandler = nil
+ScaleformUI.Scaleforms.CountdownHandler = nil
 
 ScaleformUI.Scaleforms._pauseMenu = nil
 
@@ -40,6 +42,8 @@ Citizen.CreateThread(function()
     ScaleformUI.Notifications = Notifications.New()
     ScaleformUI.Scaleforms._pauseMenu = PauseMenu.New()
     ScaleformUI.Scaleforms._pauseMenu:Load()
+    ScaleformUI.Scaleforms.RankbarHandler = RankbarHandler.New()
+    ScaleformUI.Scaleforms.CountdownHandler = CountdownHandler.New()
     
     local wait = 500
     while true do


### PR DESCRIPTION
- Refactored Countdown and Rankbar in C# after various tests in Lua
- Uses promise for Load method
- Countdown returns a promise

closes #44, and fixes #38 

test was done directly doing;
```lua
CreateThread(function()
  while true do
    Wait(0)
    if IsControlJustPressed(0, 167) then
      ScaleformUI.Notifications:ShowNotification("Show Rankbar")
      ScaleformUI.Scaleforms.RankbarHandler:SetScores(0, 800, 40, 40, 1)
      ScaleformUI.Scaleforms.CountdownHandler:Start():next(function()
        ScaleformUI.Notifications:ShowNotification("Countdown finished")
      end)
    end
  end
end)
```


https://user-images.githubusercontent.com/6077794/208299424-0fc699e6-7fb6-4520-b345-4945597c435b.mp4

