### PR TITLE
Fix focusLevel and effect

### DIFF
--- a/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
+++ b/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
@@ -76,10 +76,11 @@ function MainView:Visible(visible)
         ScaleformUI.Scaleforms._pauseMenu:Visible(visible)
         if visible == true then
 			if not IsPauseMenuActive() then
+				self.focusLevel = 1
 				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
 				self:BuildPauseMenu()
 				self.OnLobbyMenuOpen(self)
-				AnimpostfxPlay("PauseMenuIn", 800, true)
+				TriggerScreenblurFadeIn(1000) --screen blur
 				ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
 				SetPlayerControl(PlayerId(), false, 0)
 				self._firstTick = true
@@ -87,9 +88,9 @@ function MainView:Visible(visible)
 			end
         else
 			ScaleformUI.Scaleforms._pauseMenu:Dispose()
-			AnimpostfxStop("PauseMenuIn")
-			AnimpostfxPlay("PauseMenuOut", 800, false)
-			self.OnLobbyMenuClose(self)
+			TriggerScreenblurFadeOut(1000)--screen blur
+			self.OnL
+			obbyMenuClose(self)
 			SetPlayerControl(PlayerId(), true, 0)
 			self._internalpool:ProcessMenus(false)
 			if IsPauseMenuActive() then


### PR DESCRIPTION
- **focusLevel**, when close pause menu on `focusLevel = 2` **(center column)**, open next time ``focusLevel`` stuck at 2 but real screen menu fouse **left column**.
- **effect** some time my script open and close pause menu fast, effect blur stuck on screen because delay time 800ms.