### PR TITLE
Fix focusLevel and blur stuck.

### DIFF
--- a/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
+++ b/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
@@ -76,10 +76,12 @@ function MainView:Visible(visible)
         ScaleformUI.Scaleforms._pauseMenu:Visible(visible)
         if visible == true then
 			if not IsPauseMenuActive() then
+				self.focusLevel = 1
+				PlaySoundFrontend(-1, "Hit_In", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
 				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
 				self:BuildPauseMenu()
 				self.OnLobbyMenuOpen(self)
-				AnimpostfxPlay("PauseMenuIn", 800, true)
+				TriggerScreenblurFadeIn(1000) --screen blur
 				ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
 				SetPlayerControl(PlayerId(), false, 0)
 				self._firstTick = true
@@ -87,12 +89,12 @@ function MainView:Visible(visible)
 			end
         else
 			ScaleformUI.Scaleforms._pauseMenu:Dispose()
-			AnimpostfxStop("PauseMenuIn")
-			AnimpostfxPlay("PauseMenuOut", 800, false)
+			TriggerScreenblurFadeOut(1000)--screen blur
 			self.OnLobbyMenuClose(self)
 			SetPlayerControl(PlayerId(), true, 0)
 			self._internalpool:ProcessMenus(false)
 			if IsPauseMenuActive() then
+				PlaySoundFrontend(-1, "Hit_Out", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
 				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, false, -1)
 			end
 			SetFrontendActive(false)


### PR DESCRIPTION
- **focusLevel** when close pause menu on `focusLevel = 2` (center column), open next time `focusLevel` stuck at 2 but real screen menu fouse left column.
- **blur stuck** some time my script open and close pause menu fast, effect blur stuck on screen because delay time `800ms`.