### PR TITLE
Fix pause menu.

### DIFF
--- a/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
+++ b/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
@@ -76,10 +76,12 @@ function MainView:Visible(visible)
         ScaleformUI.Scaleforms._pauseMenu:Visible(visible)
         if visible == true then
 			if not IsPauseMenuActive() then
+				self.focusLevel = 1
+				PlaySoundFrontend(-1, "Hit_In", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
 				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
 				self:BuildPauseMenu()
 				self.OnLobbyMenuOpen(self)
-				AnimpostfxPlay("PauseMenuIn", 800, true)
+				TriggerScreenblurFadeIn(800) --screen blur
 				ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
 				SetPlayerControl(PlayerId(), false, 0)
 				self._firstTick = true
@@ -87,12 +89,12 @@ function MainView:Visible(visible)
 			end
         else
 			ScaleformUI.Scaleforms._pauseMenu:Dispose()
-			AnimpostfxStop("PauseMenuIn")
-			AnimpostfxPlay("PauseMenuOut", 800, false)
+			TriggerScreenblurFadeOut(800) --screen blur
 			self.OnLobbyMenuClose(self)
 			SetPlayerControl(PlayerId(), true, 0)
 			self._internalpool:ProcessMenus(false)
 			if IsPauseMenuActive() then
+				PlaySoundFrontend(-1, "Hit_Out", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
 				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, false, -1)
 			end
 			SetFrontendActive(false)

--- a/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
+++ b/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
@@ -76,6 +76,9 @@ function MainView:Visible(visible)
         ScaleformUI.Scaleforms._pauseMenu:Visible(visible)
         if visible == true then
 			if not IsPauseMenuActive() then
+				self.focusLevel = 1
+				PlaySoundFrontend(-1, "Hit_In", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
+				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
 				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
 				self:BuildPauseMenu()
 				self.OnLobbyMenuOpen(self)
@@ -93,6 +96,7 @@ function MainView:Visible(visible)
 			SetPlayerControl(PlayerId(), true, 0)
 			self._internalpool:ProcessMenus(false)
 			if IsPauseMenuActive() then
+				PlaySoundFrontend(-1, "Hit_Out", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
 				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, false, -1)
 			end
 			SetFrontendActive(false)
@@ -431,7 +435,6 @@ end
 
 function MainView:GoBack()
     if self:CanPlayerCloseMenu() then
-        PlaySoundFrontend(-1, "BACK", "HUD_FRONTEND_DEFAULT_SOUNDSET", true)
         self:Visible(false)
     end
 end

--- a/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
+++ b/ScaleformUI_Lua/src/LobbyMenu/MainView.lua
@@ -76,12 +76,10 @@ function MainView:Visible(visible)
         ScaleformUI.Scaleforms._pauseMenu:Visible(visible)
         if visible == true then
 			if not IsPauseMenuActive() then
-				self.focusLevel = 1
-				PlaySoundFrontend(-1, "Hit_In", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
 				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
 				self:BuildPauseMenu()
 				self.OnLobbyMenuOpen(self)
-				TriggerScreenblurFadeIn(800) --screen blur
+				AnimpostfxPlay("PauseMenuIn", 800, true)
 				ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
 				SetPlayerControl(PlayerId(), false, 0)
 				self._firstTick = true
@@ -89,12 +87,12 @@ function MainView:Visible(visible)
 			end
         else
 			ScaleformUI.Scaleforms._pauseMenu:Dispose()
-			TriggerScreenblurFadeOut(800) --screen blur
+			AnimpostfxStop("PauseMenuIn")
+			AnimpostfxPlay("PauseMenuOut", 800, false)
 			self.OnLobbyMenuClose(self)
 			SetPlayerControl(PlayerId(), true, 0)
 			self._internalpool:ProcessMenus(false)
 			if IsPauseMenuActive() then
-				PlaySoundFrontend(-1, "Hit_Out", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
 				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, false, -1)
 			end
 			SetFrontendActive(false)

--- a/ScaleformUI_Lua/src/PauseMenu/TabView.lua
+++ b/ScaleformUI_Lua/src/PauseMenu/TabView.lua
@@ -84,27 +84,21 @@ function TabView:Visible(visible)
         self._visible = visible
         ScaleformUI.Scaleforms._pauseMenu:Visible(visible)
         if visible == true then
-			if not IsPauseMenuActive() then
-				PlaySoundFrontend(-1, "Hit_In", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
-				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
-				self:BuildPauseMenu()
-				self._internalpool:ProcessMenus(true)
-				self.OnPauseMenuOpen(self)
-				TriggerScreenblurFadeIn(800) --screen blur
-				ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
-				SetPlayerControl(PlayerId(), false, 0)
-			end
+            ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
+            self:BuildPauseMenu()
+            self._internalpool:ProcessMenus(true)
+            self.OnPauseMenuOpen(self)
+            AnimpostfxPlay("PauseMenuIn", 800, true)
+            ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
+            SetPlayerControl(PlayerId(), false, 0)
         else
             ScaleformUI.Scaleforms._pauseMenu:Dispose()
-            TriggerScreenblurFadeOut(800)--screen blur
+            AnimpostfxStop("PauseMenuIn")
+            AnimpostfxPlay("PauseMenuOut", 800, false)
             self.OnPauseMenuClose(self)
             SetPlayerControl(PlayerId(), true, 0)
             self._internalpool:ProcessMenus(false)
-			if IsPauseMenuActive() then
-				PlaySoundFrontend(-1, "Hit_Out", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
-				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
-			end
-			SetFrontendActive(false)
+            ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
         end
     else
         return self._visible

--- a/ScaleformUI_Lua/src/PauseMenu/TabView.lua
+++ b/ScaleformUI_Lua/src/PauseMenu/TabView.lua
@@ -84,13 +84,17 @@ function TabView:Visible(visible)
         self._visible = visible
         ScaleformUI.Scaleforms._pauseMenu:Visible(visible)
         if visible == true then
-            ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
-            self:BuildPauseMenu()
-            self._internalpool:ProcessMenus(true)
-            self.OnPauseMenuOpen(self)
-            AnimpostfxPlay("PauseMenuIn", 800, true)
-            ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
-            SetPlayerControl(PlayerId(), false, 0)
+			if not IsPauseMenuActive() then
+				self.focusLevel = 1
+				PlaySoundFrontend(-1, "Hit_In", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
+				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
+				self:BuildPauseMenu()
+				self._internalpool:ProcessMenus(true)
+				self.OnPauseMenuOpen(self)
+				AnimpostfxPlay("PauseMenuIn", 800, true)
+				ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
+				SetPlayerControl(PlayerId(), false, 0)
+			end
         else
             ScaleformUI.Scaleforms._pauseMenu:Dispose()
             AnimpostfxStop("PauseMenuIn")
@@ -98,7 +102,11 @@ function TabView:Visible(visible)
             self.OnPauseMenuClose(self)
             SetPlayerControl(PlayerId(), true, 0)
             self._internalpool:ProcessMenus(false)
-            ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
+			if IsPauseMenuActive() then
+				PlaySoundFrontend(-1, "Hit_Out", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
+				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
+			end
+			SetFrontendActive(false)
         end
     else
         return self._visible
@@ -444,7 +452,6 @@ function TabView:Select()
 end
 
 function TabView:GoBack()
-    PlaySoundFrontend(-1, "BACK", "HUD_FRONTEND_DEFAULT_SOUNDSET", true)
     if self:FocusLevel() > 0 then
         if self:FocusLevel() == 1 then
             local tab = self.Tabs[self.Index]

--- a/ScaleformUI_Lua/src/PauseMenu/TabView.lua
+++ b/ScaleformUI_Lua/src/PauseMenu/TabView.lua
@@ -84,21 +84,27 @@ function TabView:Visible(visible)
         self._visible = visible
         ScaleformUI.Scaleforms._pauseMenu:Visible(visible)
         if visible == true then
-            ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
-            self:BuildPauseMenu()
-            self._internalpool:ProcessMenus(true)
-            self.OnPauseMenuOpen(self)
-            AnimpostfxPlay("PauseMenuIn", 800, true)
-            ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
-            SetPlayerControl(PlayerId(), false, 0)
+			if not IsPauseMenuActive() then
+				PlaySoundFrontend(-1, "Hit_In", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
+				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
+				self:BuildPauseMenu()
+				self._internalpool:ProcessMenus(true)
+				self.OnPauseMenuOpen(self)
+				TriggerScreenblurFadeIn(800) --screen blur
+				ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
+				SetPlayerControl(PlayerId(), false, 0)
+			end
         else
             ScaleformUI.Scaleforms._pauseMenu:Dispose()
-            AnimpostfxStop("PauseMenuIn")
-            AnimpostfxPlay("PauseMenuOut", 800, false)
+            TriggerScreenblurFadeOut(800)--screen blur
             self.OnPauseMenuClose(self)
             SetPlayerControl(PlayerId(), true, 0)
             self._internalpool:ProcessMenus(false)
-            ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
+			if IsPauseMenuActive() then
+				PlaySoundFrontend(-1, "Hit_Out", "PLAYER_SWITCH_CUSTOM_SOUNDSET")
+				ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
+			end
+			SetFrontendActive(false)
         end
     else
         return self._visible

--- a/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
@@ -19,7 +19,8 @@ AddEventHandler("onResourceStop", function(resName)
     if resName == GetCurrentResourceName() then
         if IsPauseMenuActive() and GetCurrentFrontendMenuVersion() == -2060115030 then
             ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
-            TriggerScreenblurFadeOut(0) --screen blur
+            AnimpostfxStop("PauseMenuIn");
+            AnimpostfxPlay("PauseMenuOut", 800, false);
         end
         ScaleformUI.Scaleforms._pauseMenu:Dispose()
         ScaleformUI.Scaleforms._ui:CallFunction("CLEAR_ALL", false)

--- a/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
@@ -19,8 +19,7 @@ AddEventHandler("onResourceStop", function(resName)
     if resName == GetCurrentResourceName() then
         if IsPauseMenuActive() and GetCurrentFrontendMenuVersion() == -2060115030 then
             ActivateFrontendMenu(`FE_MENU_VERSION_EMPTY_NO_BACKGROUND`, true, -1)
-            AnimpostfxStop("PauseMenuIn");
-            AnimpostfxPlay("PauseMenuOut", 800, false);
+            TriggerScreenblurFadeOut(0) --screen blur
         end
         ScaleformUI.Scaleforms._pauseMenu:Dispose()
         ScaleformUI.Scaleforms._ui:CallFunction("CLEAR_ALL", false)


### PR DESCRIPTION
- **focusLevel** when close pause menu on `focusLevel = 2` (**center column**), open same menu next time `focusLevel` stuck at 2 but on real screen menu fouse **left column** will make this wrong.
```lua
lobbyMenu.SettingsColumn.OnIndexChanged = function(idx) -- focusLevel == 1
	
end

lobbyMenu.PlayersColumn.OnIndexChanged = function(idx) -- focusLevel == 2
	
end
```
- **Blur effect stuck** some time my script open and close pause menu fast, effect blur stuck on screen because delay effect time 800ms.
- Add open and close sound.