### PR TITLE
Fixed wrong control index + Left click select

### DIFF
--- a/ScaleformUI_Lua/src/base/UIMenu.lua
+++ b/ScaleformUI_Lua/src/base/UIMenu.lua
@@ -157,7 +157,8 @@ function UIMenu.New(Title, Subtitle, X, Y, glare, txtDictionary, txtName, altern
                     { 0, 75 }, -- Exit Vehicle
                 },
                 Keyboard = {
-                    { 0, 0 },   -- Camera
+                    { 0, 2 }, -- Look Up and Down
+                    { 0, 1 }, -- Look Left and Right
                     { 0, 201 }, -- Select
                     { 0, 195 }, -- X axis
                     { 0, 196 }, -- Y axis
@@ -848,6 +849,14 @@ function UIMenu:ProcessControl()
         Citizen.CreateThread(function()
             self:SelectItem()
             Citizen.Wait(125)       
+            return
+        end)
+    end
+    
+    if self.Controls.Select.Enabled and not self._isBuilding and (IsDisabledControlJustPressed(0, 24) or IsDisabledControlJustPressed(1, 24) or IsDisabledControlJustPressed(2, 24)) then
+        Citizen.CreateThread(function()
+            self:SelectItem()
+            Citizen.Wait(125)
             return
         end)
     end


### PR DESCRIPTION
Left clicking now select the current menu (same as Right click would go back)