### PR TITLE
tweak(ScaleformUI_Lua/src/scaleforms/mainScalefrom): Thread, wait value reset

### DIFF
--- a/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
@@ -91,7 +91,7 @@ Citizen.CreateThread(function()
             (ScaleformUI.Scaleforms.JobMissionSelector.enabled or ScaleformUI.Scaleforms.JobMissionSelector._sc == nil) and
             (not ScaleformUI.Scaleforms.InstructionalButtons._enabled or (ScaleformUI.Scaleforms.InstructionalButtons.ControlButtons == nil or #ScaleformUI.Scaleforms.InstructionalButtons.ControlButtons == 0 and not ScaleformUI.Scaleforms.InstructionalButtons.IsSaving))
         then
-            wait = 500
+            wait = 850
         end
 
         Citizen.Wait(wait)

--- a/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/mainScaleform.lua
@@ -45,8 +45,9 @@ Citizen.CreateThread(function()
     ScaleformUI.Scaleforms.RankbarHandler = RankbarHandler.New()
     ScaleformUI.Scaleforms.CountdownHandler = CountdownHandler.New()
     
-    local wait = 500
+    local wait = 850
     while true do
+        wait = 850
         if not IsPauseMenuActive() then
             if ScaleformUI.Scaleforms.BigMessageInstance._sc ~= 0 then
                 ScaleformUI.Scaleforms.BigMessageInstance:Update()


### PR DESCRIPTION
reset wait value to origin value (performance)

This thread doesn't need to be read every 0 tick, when menu, instructional button ... is visible, wait set to 0, but when menu.. is hide wait keep 0 value for nothing so wait is setting per default to 850 when loop start and set to 0 only if he need it

sorry for my bad english, and nice work