### PR TITLE
C#: Instructional button fixes

### DIFF
--- a/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
@@ -195,7 +195,10 @@ namespace ScaleformUI
 
         public void InvokeEvent(InstructionalButton control)
         {
-            OnControlSelected?.Invoke(control);
+            if (API.UpdateOnscreenKeyboard() == 0)
+                return;
+
+            OnControlSelected?.Invoke(control);          
         }
     }
 

--- a/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
@@ -208,9 +208,9 @@ namespace ScaleformUI
         private bool _useMouseButtons;
         private bool _enabled = false;
         internal bool _isUsingKeyboard;
-        internal bool _changed = true;
         internal int savingTimer = 0;
         private bool _isSaving = false;
+        internal static bool _changed = true;
 
         /// <summary>
         /// Show or Hide the Instructional Buttons
@@ -464,5 +464,10 @@ namespace ScaleformUI
         }
 
         public static bool IsControlJustPressed(Control control, PadCheck keyboardOnly = PadCheck.Any) => Game.IsControlJustPressed(2, control) && (keyboardOnly == PadCheck.Keyboard ? API.IsUsingKeyboard(2) : keyboardOnly != PadCheck.Controller || !API.IsUsingKeyboard(2));
+
+        /// <summary>
+        /// Updates the instructional button text.
+        /// </summary>
+        public static void ForceUpdate() => _changed = true;   
     }
 }


### PR DESCRIPTION
• Fixed on screen keyboard instructional button press conflicts.
• Added a force update method to refresh the button text.