### PR TITLE
chore: replace game.gametime with global game timer

### DIFF
--- a/MenuExample/MenuExample.cs
+++ b/MenuExample/MenuExample.cs
@@ -1476,6 +1476,12 @@ public class MenuExample : BaseScript
 
             if (Game.IsControlJustPressed(0, (Control)170)) // F3
             {
+                if (ScaleformUI.ScaleformUI.JobMissionSelection.Enabled)
+                {
+                    ScaleformUI.ScaleformUI.JobMissionSelection.Enabled = false;
+                    return;
+                }
+
                 long txd = API.CreateRuntimeTxd("test");
                 long _paneldui = API.CreateDui("https://i.imgur.com/mH0Y65C.gif", 288, 160);
                 API.CreateRuntimeTextureFromDuiHandle(txd, "panelbackground", API.GetDuiHandle(_paneldui));

--- a/ScaleformUI_Csharp/LobbyMenu/MainView.cs
+++ b/ScaleformUI_Csharp/LobbyMenu/MainView.cs
@@ -411,7 +411,7 @@ namespace ScaleformUI.LobbyMenu
             if (!Visible || TemporarilyHidden) return;
             if (Game.IsControlPressed(2, Control.PhoneUp))
             {
-                if (Game.GameTime - time > delay)
+                if (ScaleformUI.GlobalGameTimer - time > delay)
                 {
                     ButtonDelay();
                     GoUp();
@@ -419,7 +419,7 @@ namespace ScaleformUI.LobbyMenu
             }
             else if (Game.IsControlPressed(2, Control.PhoneDown))
             {
-                if (Game.GameTime - time > delay)
+                if (ScaleformUI.GlobalGameTimer - time > delay)
                 {
                     ButtonDelay();
                     GoDown();
@@ -428,7 +428,7 @@ namespace ScaleformUI.LobbyMenu
 
             else if (Game.IsControlPressed(2, Control.PhoneLeft))
             {
-                if (Game.GameTime - time > delay)
+                if (ScaleformUI.GlobalGameTimer - time > delay)
                 {
                     ButtonDelay();
                     GoLeft();
@@ -436,7 +436,7 @@ namespace ScaleformUI.LobbyMenu
             }
             else if (Game.IsControlPressed(2, Control.PhoneRight))
             {
-                if (Game.GameTime - time > delay)
+                if (ScaleformUI.GlobalGameTimer - time > delay)
                 {
                     ButtonDelay();
                     GoRight();
@@ -727,7 +727,7 @@ namespace ScaleformUI.LobbyMenu
                 if (delay < 50) delay = 50;
             }
             // Reset the time to the current game timer.
-            time = Game.GameTime;
+            time = ScaleformUI.GlobalGameTimer;
         }
 
         internal void SendPauseMenuOpen()

--- a/ScaleformUI_Csharp/LobbyMenu/MainView.cs
+++ b/ScaleformUI_Csharp/LobbyMenu/MainView.cs
@@ -411,7 +411,7 @@ namespace ScaleformUI.LobbyMenu
             if (!Visible || TemporarilyHidden) return;
             if (Game.IsControlPressed(2, Control.PhoneUp))
             {
-                if (ScaleformUI.GlobalGameTimer - time > delay)
+                if (ScaleformUI.GameTime - time > delay)
                 {
                     ButtonDelay();
                     GoUp();
@@ -419,7 +419,7 @@ namespace ScaleformUI.LobbyMenu
             }
             else if (Game.IsControlPressed(2, Control.PhoneDown))
             {
-                if (ScaleformUI.GlobalGameTimer - time > delay)
+                if (ScaleformUI.GameTime - time > delay)
                 {
                     ButtonDelay();
                     GoDown();
@@ -428,7 +428,7 @@ namespace ScaleformUI.LobbyMenu
 
             else if (Game.IsControlPressed(2, Control.PhoneLeft))
             {
-                if (ScaleformUI.GlobalGameTimer - time > delay)
+                if (ScaleformUI.GameTime - time > delay)
                 {
                     ButtonDelay();
                     GoLeft();
@@ -436,7 +436,7 @@ namespace ScaleformUI.LobbyMenu
             }
             else if (Game.IsControlPressed(2, Control.PhoneRight))
             {
-                if (ScaleformUI.GlobalGameTimer - time > delay)
+                if (ScaleformUI.GameTime - time > delay)
                 {
                     ButtonDelay();
                     GoRight();
@@ -727,7 +727,7 @@ namespace ScaleformUI.LobbyMenu
                 if (delay < 50) delay = 50;
             }
             // Reset the time to the current game timer.
-            time = ScaleformUI.GlobalGameTimer;
+            time = ScaleformUI.GameTime;
         }
 
         internal void SendPauseMenuOpen()

--- a/ScaleformUI_Csharp/PauseMenu/TabView.cs
+++ b/ScaleformUI_Csharp/PauseMenu/TabView.cs
@@ -1177,18 +1177,18 @@ namespace ScaleformUI.PauseMenu
 
             if (Game.IsControlPressed(2, Control.LookUpOnly) && !IsUsingKeyboard(2))
             {
-                if (ScaleformUI.GlobalGameTimer - _timer > 175)
+                if (ScaleformUI.GameTime - _timer > 175)
                 {
                     _pause.SendScrollEvent(-1);
-                    _timer = ScaleformUI.GlobalGameTimer;
+                    _timer = ScaleformUI.GameTime;
                 }
             }
             else if (Game.IsControlPressed(2, Control.LookDownOnly) && !IsUsingKeyboard(2))
             {
-                if (ScaleformUI.GlobalGameTimer - _timer > 175)
+                if (ScaleformUI.GameTime - _timer > 175)
                 {
                     _pause.SendScrollEvent(1);
-                    _timer = ScaleformUI.GlobalGameTimer;
+                    _timer = ScaleformUI.GameTime;
                 }
             }
         }

--- a/ScaleformUI_Csharp/PauseMenu/TabView.cs
+++ b/ScaleformUI_Csharp/PauseMenu/TabView.cs
@@ -1177,18 +1177,18 @@ namespace ScaleformUI.PauseMenu
 
             if (Game.IsControlPressed(2, Control.LookUpOnly) && !IsUsingKeyboard(2))
             {
-                if (Game.GameTime - _timer > 175)
+                if (ScaleformUI.GlobalGameTimer - _timer > 175)
                 {
                     _pause.SendScrollEvent(-1);
-                    _timer = Game.GameTime;
+                    _timer = ScaleformUI.GlobalGameTimer;
                 }
             }
             else if (Game.IsControlPressed(2, Control.LookDownOnly) && !IsUsingKeyboard(2))
             {
-                if (Game.GameTime - _timer > 175)
+                if (ScaleformUI.GlobalGameTimer - _timer > 175)
                 {
                     _pause.SendScrollEvent(1);
-                    _timer = Game.GameTime;
+                    _timer = ScaleformUI.GlobalGameTimer;
                 }
             }
         }

--- a/ScaleformUI_Csharp/Scaleforms/BigFeed/BigFeedHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/BigFeed/BigFeedHandler.cs
@@ -1,5 +1,4 @@
 ﻿using CitizenFX.Core;
-using System;
 using static CitizenFX.Core.Native.API;
 
 namespace ScaleformUI
@@ -112,8 +111,8 @@ namespace ScaleformUI
             if (_sc != null) return;
             _sc = new Scaleform("GTAV_ONLINE");
             int timeout = 1000;
-            DateTime start = DateTime.Now;
-            while (!_sc.IsLoaded && DateTime.Now.Subtract(start).TotalMilliseconds < timeout) await BaseScript.Delay(0);
+            int start = ScaleformUI.GameTime;
+            while (!_sc.IsLoaded && ScaleformUI.GameTime - start < timeout) await BaseScript.Delay(0);
             _sc.CallFunction("HIDE_ONLINE_LOGO");
         }
         private void Dispose()

--- a/ScaleformUI_Csharp/Scaleforms/BigMessage/BigMessage.cs
+++ b/ScaleformUI_Csharp/Scaleforms/BigMessage/BigMessage.cs
@@ -29,8 +29,8 @@ namespace ScaleformUI
             if (_sc != null) return;
             _sc = new Scaleform("MP_BIG_MESSAGE_FREEMODE");
             var timeout = 1000;
-            var start = ScaleformUI.GlobalGameTimer;
-            while (!_sc.IsLoaded && ScaleformUI.GlobalGameTimer - start < timeout) await BaseScript.Delay(0);
+            var start = ScaleformUI.GameTime;
+            while (!_sc.IsLoaded && ScaleformUI.GameTime - start < timeout) await BaseScript.Delay(0);
         }
 
         public async void Dispose()
@@ -53,7 +53,7 @@ namespace ScaleformUI
         public async void ShowMissionPassedMessage(string msg, int time = 5000, bool manualDispose = false)
         {
             await Load();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             ManualDispose = manualDispose;
             _sc.CallFunction("SHOW_MISSION_PASSED_MESSAGE", msg, "", 100, true, 0, true);
             _duration = time;
@@ -62,7 +62,7 @@ namespace ScaleformUI
         public async void ShowColoredShard(string msg, string desc, HudColor textColor, HudColor bgColor, int time = 5000, bool manualDispose = false)
         {
             await Load();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             ManualDispose = manualDispose;
             _sc.CallFunction("SHOW_SHARD_CENTERED_MP_MESSAGE", msg, desc, (int)bgColor, (int)textColor);
             _duration = time;
@@ -71,7 +71,7 @@ namespace ScaleformUI
         public async void ShowOldMessage(string msg, int time = 5000, bool manualDispose = false)
         {
             await Load();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             ManualDispose = manualDispose;
             _sc.CallFunction("SHOW_MISSION_PASSED_MESSAGE", msg);
             _duration = time;
@@ -80,7 +80,7 @@ namespace ScaleformUI
         public async void ShowSimpleShard(string title, string subtitle, int time = 5000, bool manualDispose = false)
         {
             await Load();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             ManualDispose = manualDispose;
             _sc.CallFunction("SHOW_SHARD_CREW_RANKUP_MP_MESSAGE", title, subtitle);
             _duration = time;
@@ -89,7 +89,7 @@ namespace ScaleformUI
         public async void ShowRankupMessage(string msg, string subtitle, int rank, int time = 5000, bool manualDispose = false)
         {
             await Load();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             ManualDispose = manualDispose;
             _sc.CallFunction("SHOW_BIG_MP_MESSAGE", msg, subtitle, rank, "", "");
             _duration = time;
@@ -98,7 +98,7 @@ namespace ScaleformUI
         public async void ShowWeaponPurchasedMessage(string bigMessage, string weaponName, WeaponHash weapon, int time = 5000, bool manualDispose = false)
         {
             await Load();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             ManualDispose = manualDispose;
             _sc.CallFunction("SHOW_WEAPON_PURCHASED", bigMessage, weaponName, unchecked((int)weapon), "", 100);
             _duration = time;
@@ -107,7 +107,7 @@ namespace ScaleformUI
         public async void ShowMpMessageLarge(string msg, int time = 5000, bool manualDispose = false)
         {
             await Load();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             ManualDispose = manualDispose;
             _sc.CallFunction("SHOW_CENTERED_MP_MESSAGE_LARGE", msg, "test", 100, true, 100);
             _sc.CallFunction("TRANSITION_IN");
@@ -117,7 +117,7 @@ namespace ScaleformUI
         public async void ShowMpWastedMessage(string msg, string sub, int time = 5000, bool manualDispose = false)
         {
             await Load();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             ManualDispose = manualDispose;
             _sc.CallFunction("SHOW_SHARD_WASTED_MP_MESSAGE", msg, sub);
             _duration = time;
@@ -135,7 +135,7 @@ namespace ScaleformUI
 
             if (ManualDispose) return;
 
-            if (_start != 0 && (ScaleformUI.GlobalGameTimer - _start) > _duration)
+            if (_start != 0 && (ScaleformUI.GameTime - _start) > _duration)
             {
                 if (!_transitionExecuted)
                 {

--- a/ScaleformUI_Csharp/Scaleforms/Countdown/CountdownHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Countdown/CountdownHandler.cs
@@ -1,7 +1,5 @@
 ﻿using CitizenFX.Core;
 using CitizenFX.Core.Native;
-using System;
-using System.Threading.Tasks;
 
 namespace ScaleformUI.Scaleforms.Countdown
 {
@@ -64,8 +62,8 @@ namespace ScaleformUI.Scaleforms.Countdown
             API.RequestScriptAudioBank("HUD_321_GO", false);
             _sc = new Scaleform(SCALEFORM_NAME);
             var timeout = 1000;
-            var start = DateTime.Now;
-            while (!_sc.IsLoaded && DateTime.Now.Subtract(start).TotalMilliseconds < timeout) await BaseScript.Delay(0);
+            int start = ScaleformUI.GameTime;
+            while (!_sc.IsLoaded && ScaleformUI.GameTime - start < timeout) await BaseScript.Delay(0);
         }
 
         private async void Dispose()

--- a/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
@@ -247,8 +247,8 @@ namespace ScaleformUI
             if (_sc != null) return;
             _sc = new Scaleform("INSTRUCTIONAL_BUTTONS");
             int timeout = 1000;
-            DateTime start = DateTime.Now;
-            while (!API.HasScaleformMovieLoaded(_sc.Handle) && DateTime.Now.Subtract(start).TotalMilliseconds < timeout) await BaseScript.Delay(0);
+            int start = ScaleformUI.GameTime;
+            while (!_sc.IsLoaded && ScaleformUI.GameTime - start < timeout) await BaseScript.Delay(0);
         }
 
         /// <summary>

--- a/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
@@ -326,9 +326,9 @@ namespace ScaleformUI
         {
             _isSaving = true;
             _changed = true;
-            savingTimer = ScaleformUI.GlobalGameTimer;
+            savingTimer = ScaleformUI.GameTime;
             Screen.LoadingPrompt.Show(text, spinnerType);
-            while (ScaleformUI.GlobalGameTimer - savingTimer <= time) await BaseScript.Delay(100);
+            while (ScaleformUI.GameTime - savingTimer <= time) await BaseScript.Delay(100);
             Screen.LoadingPrompt.Hide();
             _isSaving = false;
         }
@@ -342,7 +342,7 @@ namespace ScaleformUI
         {
             _isSaving = true;
             _changed = true;
-            savingTimer = ScaleformUI.GlobalGameTimer;
+            savingTimer = ScaleformUI.GameTime;
             Screen.LoadingPrompt.Show(text, spinnerType);
         }
 

--- a/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Instructional_Buttons/InstructionalButtons.cs
@@ -1,10 +1,7 @@
 ﻿using CitizenFX.Core;
 using CitizenFX.Core.Native;
 using CitizenFX.Core.UI;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 
 namespace ScaleformUI
 {
@@ -329,9 +326,9 @@ namespace ScaleformUI
         {
             _isSaving = true;
             _changed = true;
-            savingTimer = Game.GameTime;
+            savingTimer = ScaleformUI.GlobalGameTimer;
             Screen.LoadingPrompt.Show(text, spinnerType);
-            while (Game.GameTime - savingTimer <= time) await BaseScript.Delay(100);
+            while (ScaleformUI.GlobalGameTimer - savingTimer <= time) await BaseScript.Delay(100);
             Screen.LoadingPrompt.Hide();
             _isSaving = false;
         }
@@ -345,7 +342,7 @@ namespace ScaleformUI
         {
             _isSaving = true;
             _changed = true;
-            savingTimer = Game.GameTime;
+            savingTimer = ScaleformUI.GlobalGameTimer;
             Screen.LoadingPrompt.Show(text, spinnerType);
         }
 

--- a/ScaleformUI_Csharp/Scaleforms/MediumMessage/MediumMessage.cs
+++ b/ScaleformUI_Csharp/Scaleforms/MediumMessage/MediumMessage.cs
@@ -32,7 +32,7 @@ namespace ScaleformUI
         public async void ShowColoredShard(string msg, string desc, HudColor bgColor, bool useDarkerShard = false, bool useCondensedShard = false, int time = 5000)
         {
             await Load();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             _sc.CallFunction("SHOW_SHARD_MIDSIZED_MESSAGE", msg, desc, (int)bgColor, useDarkerShard, useCondensedShard);
             _timer = time;
             _hasAnimatedOut = false;
@@ -41,7 +41,7 @@ namespace ScaleformUI
         internal async void Update()
         {
             _sc.Render2D();
-            if (_start != 0 && ScaleformUI.GlobalGameTimer - _start > _timer)
+            if (_start != 0 && ScaleformUI.GameTime - _start > _timer)
             {
                 if (!_hasAnimatedOut)
                 {

--- a/ScaleformUI_Csharp/Scaleforms/MediumMessage/MediumMessage.cs
+++ b/ScaleformUI_Csharp/Scaleforms/MediumMessage/MediumMessage.cs
@@ -32,7 +32,7 @@ namespace ScaleformUI
         public async void ShowColoredShard(string msg, string desc, HudColor bgColor, bool useDarkerShard = false, bool useCondensedShard = false, int time = 5000)
         {
             await Load();
-            _start = Game.GameTime;
+            _start = ScaleformUI.GlobalGameTimer;
             _sc.CallFunction("SHOW_SHARD_MIDSIZED_MESSAGE", msg, desc, (int)bgColor, useDarkerShard, useCondensedShard);
             _timer = time;
             _hasAnimatedOut = false;
@@ -41,7 +41,7 @@ namespace ScaleformUI
         internal async void Update()
         {
             _sc.Render2D();
-            if (_start != 0 && Game.GameTime - _start > _timer)
+            if (_start != 0 && ScaleformUI.GlobalGameTimer - _start > _timer)
             {
                 if (!_hasAnimatedOut)
                 {

--- a/ScaleformUI_Csharp/Scaleforms/MediumMessage/MediumMessage.cs
+++ b/ScaleformUI_Csharp/Scaleforms/MediumMessage/MediumMessage.cs
@@ -1,6 +1,4 @@
 ﻿using CitizenFX.Core;
-using System;
-using System.Threading.Tasks;
 
 namespace ScaleformUI
 {
@@ -19,8 +17,8 @@ namespace ScaleformUI
             _sc = new Scaleform("MIDSIZED_MESSAGE");
 
             var timeout = 1000;
-            var start = DateTime.Now;
-            while (!_sc.IsLoaded && DateTime.Now.Subtract(start).TotalMilliseconds < timeout) await BaseScript.Delay(0);
+            int start = ScaleformUI.GameTime;
+            while (!_sc.IsLoaded && ScaleformUI.GameTime - start < timeout) await BaseScript.Delay(0);
         }
 
         public void Dispose()

--- a/ScaleformUI_Csharp/Scaleforms/MissionSelector/MissionSelectorHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/MissionSelector/MissionSelectorHandler.cs
@@ -1,9 +1,5 @@
 ﻿using CitizenFX.Core;
 using CitizenFX.Core.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ScaleformUI
 {
@@ -179,8 +175,8 @@ namespace ScaleformUI
             if (_sc != null) return;
             _sc = new("MP_NEXT_JOB_SELECTION");
             var timeout = 1000;
-            var start = DateTime.Now;
-            while (!_sc.IsLoaded && DateTime.Now.Subtract(start).TotalMilliseconds < timeout) await BaseScript.Delay(0);
+            int start = ScaleformUI.GameTime;
+            while (!_sc.IsLoaded && ScaleformUI.GameTime - start < timeout) await BaseScript.Delay(0);
         }
 
         int eventType = 0;

--- a/ScaleformUI_Csharp/Scaleforms/MissionSelector/MissionSelectorHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/MissionSelector/MissionSelectorHandler.cs
@@ -89,6 +89,7 @@ namespace ScaleformUI
 
         public void Dispose()
         {
+            Votes = new int[9];
             _sc.Dispose();
             _sc = null;
         }

--- a/ScaleformUI_Csharp/Scaleforms/MultiplayerChat/MultiplayerChatHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/MultiplayerChat/MultiplayerChatHandler.cs
@@ -18,8 +18,8 @@ namespace ScaleformUI.Scaleforms.MultiplayerChat
             if (_sc is not null) return;
             _sc = new Scaleform(SCALEFORM_NAME);
             int timeout = 1000;
-            int start = ScaleformUI.GlobalGameTimer;
-            while (!_sc.IsLoaded && ScaleformUI.GlobalGameTimer - start < timeout) await BaseScript.Delay(0);
+            int start = ScaleformUI.GameTime;
+            while (!_sc.IsLoaded && ScaleformUI.GameTime - start < timeout) await BaseScript.Delay(0);
             if (!_sc.IsLoaded) return;
             _sc.CallFunction("RESET");
             _sc.CallFunction("SET_FOCUS", ChatVisibility.Hidden, ChatScope.All, "All", Game.Player.Name, HudColor.HUD_COLOUR_WHITE);
@@ -38,7 +38,7 @@ namespace ScaleformUI.Scaleforms.MultiplayerChat
             else if (visibility == ChatVisibility.Hidden)
                 _isTyping = false;
             else if (visibility == ChatVisibility.Default)
-                _start = ScaleformUI.GlobalGameTimer;
+                _start = ScaleformUI.GameTime;
 
             _sc.CallFunction("SET_FOCUS", visibility, scope, scopeText, playerName, color);
         }
@@ -73,7 +73,7 @@ namespace ScaleformUI.Scaleforms.MultiplayerChat
             if (_sc is null || !_sc.IsLoaded) return;
             _sc.Render2D();
 
-            if (!_isTyping && ScaleformUI.GlobalGameTimer - _start > _duration)
+            if (!_isTyping && ScaleformUI.GameTime - _start > _duration)
                 Close();
         }
     }

--- a/ScaleformUI_Csharp/Scaleforms/PopupWarning/PopupWarning.cs
+++ b/ScaleformUI_Csharp/Scaleforms/PopupWarning/PopupWarning.cs
@@ -12,7 +12,7 @@ namespace ScaleformUI
 
     public class PopupWarning
     {
-        internal Scaleform _warning;
+        internal Scaleform _sc;
         private bool _disableControls;
         private List<InstructionalButton> _buttonList;
 
@@ -21,7 +21,7 @@ namespace ScaleformUI
         /// </summary>
         public bool IsShowing
         {
-            get => _warning != null;
+            get => _sc != null;
         }
 
         public bool IsShowingWithButtons
@@ -33,11 +33,11 @@ namespace ScaleformUI
 
         private async Task Load()
         {
-            if (_warning != null) return;
-            _warning = new Scaleform("POPUP_WARNING");
+            if (_sc != null) return;
+            _sc = new Scaleform("POPUP_WARNING");
             int timeout = 1000;
-            DateTime start = DateTime.Now;
-            while (!_warning.IsLoaded && DateTime.Now.Subtract(start).TotalMilliseconds < timeout) await BaseScript.Delay(0);
+            int start = ScaleformUI.GameTime;
+            while (!_sc.IsLoaded && ScaleformUI.GameTime - start < timeout) await BaseScript.Delay(0);
         }
 
         /// <summary>
@@ -45,10 +45,10 @@ namespace ScaleformUI
         /// </summary>
         public void Dispose()
         {
-            if (_warning == null) return;
-            _warning.CallFunction("HIDE_POPUP_WARNING", 1000);
-            _warning.Dispose();
-            _warning = null;
+            if (_sc == null) return;
+            _sc.CallFunction("HIDE_POPUP_WARNING", 1000);
+            _sc.Dispose();
+            _sc = null;
             _disableControls = false;
         }
 
@@ -63,7 +63,7 @@ namespace ScaleformUI
         public async void ShowWarning(string title, string subtitle, string prompt = "", string errorMsg = "", WarningPopupType type = WarningPopupType.Classic, bool showBackground = true)
         {
             await Load();
-            _warning.CallFunction("SHOW_POPUP_WARNING", 1000, title, subtitle, prompt, showBackground, (int)type, errorMsg);
+            _sc.CallFunction("SHOW_POPUP_WARNING", 1000, title, subtitle, prompt, showBackground, (int)type, errorMsg);
         }
 
         /// <summary>
@@ -76,8 +76,8 @@ namespace ScaleformUI
         /// <param name="type">Type of the Warning</param>
         public void UpdateWarning(string title, string subtitle, string prompt = "", string errorMsg = "", WarningPopupType type = WarningPopupType.Classic, bool showBackground = true)
         {
-            if (!_warning.IsLoaded) return;
-            _warning.CallFunction("SHOW_POPUP_WARNING", 1000, title, subtitle, prompt, showBackground, (int)type, errorMsg);
+            if (!_sc.IsLoaded) return;
+            _sc.CallFunction("SHOW_POPUP_WARNING", 1000, title, subtitle, prompt, showBackground, (int)type, errorMsg);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace ScaleformUI
             ScaleformUI.InstructionalButtons.SetInstructionalButtons(_buttonList);
             ScaleformUI.InstructionalButtons.UseMouseButtons = true;
             ScaleformUI.InstructionalButtons.ControlButtons.ForEach(x => x.OnControlSelected += X_OnControlSelected);
-            _warning.CallFunction("SHOW_POPUP_WARNING", 1000, title, subtitle, prompt, showBackground, (int)type, errorMsg);
+            _sc.CallFunction("SHOW_POPUP_WARNING", 1000, title, subtitle, prompt, showBackground, (int)type, errorMsg);
             ScaleformUI.InstructionalButtons.Enabled = true;
         }
 
@@ -113,7 +113,7 @@ namespace ScaleformUI
 
         internal void Update()
         {
-            _warning.Render2D();
+            _sc.Render2D();
         }
     }
 }

--- a/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/RankBar/RankBarHandler.cs
@@ -1,7 +1,5 @@
 ﻿using CitizenFX.Core;
 using CitizenFX.Core.Native;
-using System.Threading.Tasks;
-using System;
 
 namespace ScaleformUI.Scaleforms.RankBar
 {
@@ -28,10 +26,10 @@ namespace ScaleformUI.Scaleforms.RankBar
         public async Task Load()
         {
             var timeout = 1000;
-            var start = DateTime.Now;
 
+            int start = ScaleformUI.GameTime;
             API.RequestHudScaleform(HUD_COMPONENT_ID);
-            while (!API.HasHudScaleformLoaded(HUD_COMPONENT_ID) && DateTime.Now.Subtract(start).TotalMilliseconds < timeout)
+            while (!API.HasHudScaleformLoaded(HUD_COMPONENT_ID) && ScaleformUI.GameTime - start < timeout)
             {
                 await BaseScript.Delay(0);
             }

--- a/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
+++ b/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
@@ -7,7 +7,11 @@ namespace ScaleformUI
 {
     public class ScaleformUI : BaseScript
     {
+        /// <summary>
+        /// Provides the current game time in milliseconds.
+        /// </summary>
         public static int GameTime = API.GetGameTimer();
+
         public static PauseMenuScaleform PauseMenu { get; set; }
         public static MediumMessageHandler MedMessageInstance { get; set; }
         public static InstructionalButtonsScaleform InstructionalButtons { get; set; }
@@ -77,9 +81,13 @@ namespace ScaleformUI
             await Task.FromResult(0);
         }
 
+        /// <summary>
+        /// Updates the game time.
+        /// </summary>
+        /// <returns></returns>
         public async Task OnUpdateGlobalGameTimerAsync()
         {
-            await BaseScript.Delay(1000);
+            await BaseScript.Delay(10);
             GameTime = API.GetGameTimer();
         }
     }

--- a/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
+++ b/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
@@ -63,7 +63,7 @@ namespace ScaleformUI
             if (InstructionalButtons._sc != null && InstructionalButtons.Enabled && ((InstructionalButtons.ControlButtons != null || InstructionalButtons.ControlButtons.Count != 0) || InstructionalButtons.IsSaving))
                 InstructionalButtons.Update();
             if (Game.IsPaused) return;
-            if (Warning._warning != null)
+            if (Warning._sc != null)
                 Warning.Update();
             if (MedMessageInstance._sc != null)
                 MedMessageInstance.Update();

--- a/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
+++ b/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
@@ -2,14 +2,12 @@
 using CitizenFX.Core.Native;
 using ScaleformUI.Scaleforms.Countdown;
 using ScaleformUI.Scaleforms.RankBar;
-using System;
-using System.Threading.Tasks;
 
 namespace ScaleformUI
 {
     public class ScaleformUI : BaseScript
     {
-        public static int GlobalGameTimer = API.GetGameTimer();
+        public static int GameTime = API.GetGameTimer();
         public static PauseMenuScaleform PauseMenu { get; set; }
         public static MediumMessageHandler MedMessageInstance { get; set; }
         public static InstructionalButtonsScaleform InstructionalButtons { get; set; }
@@ -82,7 +80,7 @@ namespace ScaleformUI
         public async Task OnUpdateGlobalGameTimerAsync()
         {
             await BaseScript.Delay(1000);
-            GlobalGameTimer = API.GetGameTimer();
+            GameTime = API.GetGameTimer();
         }
     }
 }

--- a/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
+++ b/ScaleformUI_Csharp/Scaleforms/ScaleformUI/ScaleformUI.cs
@@ -87,7 +87,7 @@ namespace ScaleformUI
         /// <returns></returns>
         public async Task OnUpdateGlobalGameTimerAsync()
         {
-            await BaseScript.Delay(10);
+            await BaseScript.Delay(100);
             GameTime = API.GetGameTimer();
         }
     }

--- a/ScaleformUI_Csharp/Scaleforms/Scoreboard/PlayerListHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Scoreboard/PlayerListHandler.cs
@@ -131,7 +131,7 @@ namespace ScaleformUI
         internal void Update()
         {
             API.DrawScaleformMovie(_sc.Handle, 0.122f, 0.3f, 0.28f, 0.6f, 255, 255, 255, 255, 0);
-            if (_start != 0 && ScaleformUI.GlobalGameTimer - _start > _timer)
+            if (_start != 0 && ScaleformUI.GameTime - _start > _timer)
             {
                 CurrentPage = 0;
                 Enabled = false;
@@ -144,7 +144,7 @@ namespace ScaleformUI
         public void NextPage()
         {
             UpdateMaxPages();
-            _start = ScaleformUI.GlobalGameTimer;
+            _start = ScaleformUI.GameTime;
             _timer = 8000;
             BuildMenu();
             if (CurrentPage > MaxPages)

--- a/ScaleformUI_Csharp/Scaleforms/Scoreboard/PlayerListHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Scoreboard/PlayerListHandler.cs
@@ -1,9 +1,5 @@
 ﻿using CitizenFX.Core;
 using CitizenFX.Core.Native;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ScaleformUI
 {
@@ -51,8 +47,8 @@ namespace ScaleformUI
             if (_sc is not null) return;
             _sc = new Scaleform("MP_MM_CARD_FREEMODE");
             var timeout = 1000;
-            var start = DateTime.Now;
-            while (!_sc.IsLoaded && DateTime.Now.Subtract(start).TotalMilliseconds < timeout) await BaseScript.Delay(0);
+            int start = ScaleformUI.GameTime;
+            while (!_sc.IsLoaded && ScaleformUI.GameTime - start < timeout) await BaseScript.Delay(0);
         }
         public void Dispose()
         {

--- a/ScaleformUI_Csharp/Scaleforms/Scoreboard/PlayerListHandler.cs
+++ b/ScaleformUI_Csharp/Scaleforms/Scoreboard/PlayerListHandler.cs
@@ -131,7 +131,7 @@ namespace ScaleformUI
         internal void Update()
         {
             API.DrawScaleformMovie(_sc.Handle, 0.122f, 0.3f, 0.28f, 0.6f, 255, 255, 255, 255, 0);
-            if (_start != 0 && Game.GameTime - _start > _timer)
+            if (_start != 0 && ScaleformUI.GlobalGameTimer - _start > _timer)
             {
                 CurrentPage = 0;
                 Enabled = false;
@@ -144,7 +144,7 @@ namespace ScaleformUI
         public void NextPage()
         {
             UpdateMaxPages();
-            _start = Game.GameTime;
+            _start = ScaleformUI.GlobalGameTimer;
             _timer = 8000;
             BuildMenu();
             if (CurrentPage > MaxPages)

--- a/ScaleformUI_Csharp/UIMenu.cs
+++ b/ScaleformUI_Csharp/UIMenu.cs
@@ -2058,7 +2058,7 @@ namespace ScaleformUI
             {
                 if (isBuilding && _activeItem <= 0)
                     return;
-                if (Game.GameTime - time > delay)
+                if (ScaleformUI.GlobalGameTimer - time > delay)
                 {
                     ButtonDelay();
                     GoUp();
@@ -2067,7 +2067,7 @@ namespace ScaleformUI
 
             else if (IsControlBeingPressed(MenuControls.Down, key))
             {
-                if (Game.GameTime - time > delay)
+                if (ScaleformUI.GlobalGameTimer - time > delay)
                 {
                     ButtonDelay();
                     GoDown();
@@ -2076,7 +2076,7 @@ namespace ScaleformUI
 
             else if (IsControlBeingPressed(MenuControls.Left, key))
             {
-                if (Game.GameTime - time > delay)
+                if (ScaleformUI.GlobalGameTimer - time > delay)
                 {
                     ButtonDelay();
                     GoLeft();
@@ -2085,7 +2085,7 @@ namespace ScaleformUI
 
             else if (IsControlBeingPressed(MenuControls.Right, key))
             {
-                if (Game.GameTime - time > delay)
+                if (ScaleformUI.GlobalGameTimer - time > delay)
                 {
                     ButtonDelay();
                     GoRight();
@@ -2119,7 +2119,7 @@ namespace ScaleformUI
                 if (delay < 50) delay = 50;
             }
             // Reset the time to the current game timer.
-            time = Game.GameTime;
+            time = ScaleformUI.GlobalGameTimer;
         }
 
         /// <summary>
@@ -2211,13 +2211,13 @@ namespace ScaleformUI
 
                 }
             }
-            var timer = Game.GameTime;
+            var timer = ScaleformUI.GlobalGameTimer;
             if (MenuItems.Count == 0)
             {
                 while (MenuItems.Count == 0)
                 {
                     await BaseScript.Delay(0);
-                    if (Game.GameTime - timer > 150)
+                    if (ScaleformUI.GlobalGameTimer - timer > 150)
                     {
                         ScaleformUI._ui.CallFunction("SET_CURRENT_ITEM", CurrentSelection);
                         return;
@@ -2440,13 +2440,13 @@ namespace ScaleformUI
 
                 }
             }
-            var timer = Game.GameTime;
+            var timer = ScaleformUI.GlobalGameTimer;
             if (MenuItems.Count == 0)
             {
                 while (MenuItems.Count == 0)
                 {
                     await BaseScript.Delay(0);
-                    if (Game.GameTime - timer > 150)
+                    if (ScaleformUI.GlobalGameTimer - timer > 150)
                     {
                         ScaleformUI._ui.CallFunction("SET_CURRENT_ITEM", CurrentSelection);
                         return;

--- a/ScaleformUI_Csharp/UIMenu.cs
+++ b/ScaleformUI_Csharp/UIMenu.cs
@@ -2058,7 +2058,7 @@ namespace ScaleformUI
             {
                 if (isBuilding && _activeItem <= 0)
                     return;
-                if (ScaleformUI.GlobalGameTimer - time > delay)
+                if (ScaleformUI.GameTime - time > delay)
                 {
                     ButtonDelay();
                     GoUp();
@@ -2067,7 +2067,7 @@ namespace ScaleformUI
 
             else if (IsControlBeingPressed(MenuControls.Down, key))
             {
-                if (ScaleformUI.GlobalGameTimer - time > delay)
+                if (ScaleformUI.GameTime - time > delay)
                 {
                     ButtonDelay();
                     GoDown();
@@ -2076,7 +2076,7 @@ namespace ScaleformUI
 
             else if (IsControlBeingPressed(MenuControls.Left, key))
             {
-                if (ScaleformUI.GlobalGameTimer - time > delay)
+                if (ScaleformUI.GameTime - time > delay)
                 {
                     ButtonDelay();
                     GoLeft();
@@ -2085,7 +2085,7 @@ namespace ScaleformUI
 
             else if (IsControlBeingPressed(MenuControls.Right, key))
             {
-                if (ScaleformUI.GlobalGameTimer - time > delay)
+                if (ScaleformUI.GameTime - time > delay)
                 {
                     ButtonDelay();
                     GoRight();
@@ -2119,7 +2119,7 @@ namespace ScaleformUI
                 if (delay < 50) delay = 50;
             }
             // Reset the time to the current game timer.
-            time = ScaleformUI.GlobalGameTimer;
+            time = ScaleformUI.GameTime;
         }
 
         /// <summary>
@@ -2211,13 +2211,13 @@ namespace ScaleformUI
 
                 }
             }
-            var timer = ScaleformUI.GlobalGameTimer;
+            var timer = ScaleformUI.GameTime;
             if (MenuItems.Count == 0)
             {
                 while (MenuItems.Count == 0)
                 {
                     await BaseScript.Delay(0);
-                    if (ScaleformUI.GlobalGameTimer - timer > 150)
+                    if (ScaleformUI.GameTime - timer > 150)
                     {
                         ScaleformUI._ui.CallFunction("SET_CURRENT_ITEM", CurrentSelection);
                         return;
@@ -2440,13 +2440,13 @@ namespace ScaleformUI
 
                 }
             }
-            var timer = ScaleformUI.GlobalGameTimer;
+            var timer = ScaleformUI.GameTime;
             if (MenuItems.Count == 0)
             {
                 while (MenuItems.Count == 0)
                 {
                     await BaseScript.Delay(0);
-                    if (ScaleformUI.GlobalGameTimer - timer > 150)
+                    if (ScaleformUI.GameTime - timer > 150)
                     {
                         ScaleformUI._ui.CallFunction("SET_CURRENT_ITEM", CurrentSelection);
                         return;


### PR DESCRIPTION
- Replace all `Game.GameTime` calls with a central `ScaleformUI.GameTime`
- Update `ScaleformUI.GameTime` every 100ms
- Replace all `DateTime` calls with `ScaleformUI.GameTime` (because we know DateTime is just slower)

Additionally;
- Reset vote count on Mission Selector when Disposed
- If F3 is pressed after opening the Mission Selector, disable it (example menu)