### PR TITLE
feat: add celebration methods

### DIFF
--- a/ScaleformUI_Lua/src/scaleforms/Celebration/Celebration.lua
+++ b/ScaleformUI_Lua/src/scaleforms/Celebration/Celebration.lua
@@ -265,16 +265,13 @@ end
 ---@see CelebrationCustomSounds
 function CelebrationInstance:SetCustomSound(soundSet)
   self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
-    0,
-    { type = "literal", data = { "Blade_Appear", soundSet } }
+    { type = "literal", data = { 0, "Blade_Appear", soundSet } }
   )
   self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
-    7,
-    { type = "literal", data = { "Blade_Beasts_Fail", soundSet } }
+    { type = "literal", data = { 7, "Blade_Beasts_Fail", soundSet } }
   )
   self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
-    8,
-    { type = "literal", data = { "Blade_Beasts_Win", soundSet } }
+    { type = "literal", data = { 8, "Blade_Beasts_Win", soundSet } }
   )
 end
 

--- a/ScaleformUI_Lua/src/scaleforms/Celebration/Celebration.lua
+++ b/ScaleformUI_Lua/src/scaleforms/Celebration/Celebration.lua
@@ -4,6 +4,21 @@ CelebrationInstance.__call = function()
   return "Celebration"
 end
 
+---@enum CelebrationSound
+CelebrationSound = {
+  ScreenSwipe = 0,
+  ScreenStats = 1,
+  ScreenFlash = 2,
+  FinishedPlace = 3,
+  Rankup = 4,
+  NumberTurn = 5,
+  NumberTurnStop = 6,
+  ScreenStart = 7,
+  Winner = 8,
+  NumberCount = 9,
+  NumberCountStop = 10
+}
+
 ---@enum CelebrationTexture
 CelebrationTexture = {
   Shard = 1,
@@ -23,13 +38,6 @@ CelebrationType = {
   Multiplayer = 1,
   Heist1 = 2,
   Heist2 = 3,
-}
-
----@enum CelebrationCustomSounds
-CelebrationCustomSounds = {
-  Default = "APT_BvS_Soundset",
-  Beast = "DLC_GR_PM_Beast_Soundset",
-  BeastRemix = "DLC_BTL_TP_Remix_Beast_Soundset"
 }
 
 ---Get the scaleform names for the celebration type
@@ -261,23 +269,15 @@ function CelebrationInstance:CreateMainStatWall(wallId, colour, alpha)
 end
 
 ---Set custom sounds for the wall
----@param soundSet CelebrationCustomSounds
----@see CelebrationCustomSounds
-function CelebrationInstance:SetCustomSound(soundSet)
+---@param id CelebrationSound
+---@param sound string
+---@param soundSet string
+---@see CelebrationSound
+function CelebrationInstance:SetCustomSound(id, sound, soundSet)
   self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
-    0,
-    { type = "literal", data = "Blade_Appear" },
-    { type = "literal", data = soundSet }
-  )
-  self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
-    7,
-    { type = "literal", data = "Blade_Beasts_Fail" },
-    { type = "literal", data = soundSet }
-  )
-  self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
-    8,
-    { type = "literal", data = "Blade_Beasts_Win" },
-    { type = "literal", data = soundSet }
+    id,
+    { type = "playerNameComp", data = sound },
+    { type = "playerNameComp", data = soundSet }
   )
 end
 
@@ -316,5 +316,27 @@ function CelebrationInstance:AddTimeToWall(wallId, time, timeTitleLabel, timeDif
     time,
     { type = "playerNameString", data = timeTitleLabel },
     timeDifference
+  )
+end
+
+---Add ready to a wall
+---@param wallId string
+---@param readyLabel string
+function CelebrationInstance:AddReadyToWall(wallId, readyLabel)
+  self:CallAllFunction("ADD_READY_TO_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    { type = "playerNameComp", data = readyLabel }
+  )
+end
+
+---Add a cash amount to a wall
+---@param wallId string @Wall ID
+---@param cashAmount number @Amount of cash
+---@param xAlign string @Alignment left, right, or center
+function CelebrationInstance:AddCashToWall(wallId, cashAmount, xAlign)
+  self:CallAllFunction("ADD_CASH_TO_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    cashAmount,
+    { type = "playerNameComp", data = xAlign }
   )
 end

--- a/ScaleformUI_Lua/src/scaleforms/Celebration/Celebration.lua
+++ b/ScaleformUI_Lua/src/scaleforms/Celebration/Celebration.lua
@@ -265,13 +265,19 @@ end
 ---@see CelebrationCustomSounds
 function CelebrationInstance:SetCustomSound(soundSet)
   self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
-    { type = "literal", data = { 0, "Blade_Appear", soundSet } }
+    0,
+    { type = "literal", data = "Blade_Appear" },
+    { type = "literal", data = soundSet }
   )
   self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
-    { type = "literal", data = { 7, "Blade_Beasts_Fail", soundSet } }
+    7,
+    { type = "literal", data = "Blade_Beasts_Fail" },
+    { type = "literal", data = soundSet }
   )
   self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
-    { type = "literal", data = { 8, "Blade_Beasts_Win", soundSet } }
+    8,
+    { type = "literal", data = "Blade_Beasts_Win" },
+    { type = "literal", data = soundSet }
   )
 end
 

--- a/ScaleformUI_Lua/src/scaleforms/Celebration/Celebration.lua
+++ b/ScaleformUI_Lua/src/scaleforms/Celebration/Celebration.lua
@@ -1,0 +1,317 @@
+CelebrationInstance = setmetatable({}, CelebrationInstance)
+CelebrationInstance.__index = CelebrationInstance
+CelebrationInstance.__call = function()
+  return "Celebration"
+end
+
+---@enum CelebrationTexture
+CelebrationTexture = {
+  Shard = 1,
+  RaceFlag = 3,
+  Grid = 6,
+  TargetAssault = 8,
+  Remix1 = 10,
+  Remix2 = 12,
+  Remix3 = 14,
+  Remix4 = 16,
+  Remix5 = 18,
+  ArenaWars = 20,
+}
+
+---@enum CelebrationType
+CelebrationType = {
+  Multiplayer = 1,
+  Heist1 = 2,
+  Heist2 = 3,
+}
+
+---@enum CelebrationCustomSounds
+CelebrationCustomSounds = {
+  Default = "APT_BvS_Soundset",
+  Beast = "DLC_GR_PM_Beast_Soundset",
+  BeastRemix = "DLC_BTL_TP_Remix_Beast_Soundset"
+}
+
+---Get the scaleform names for the celebration type
+---@param celebrationType CelebrationType
+---@return string, string, string
+local function GetCelebrationScaleforms(celebrationType)
+  if celebrationType == CelebrationType.Multiplayer then
+    return "MP_CELEBRATION", "MP_CELEBRATION_FG", "MP_CELEBRATION_BG"
+  elseif celebrationType == CelebrationType.Heist1 then
+    return "HEIST_CELEBRATION", "HEIST_CELEBRATION_FG", "HEIST_CELEBRATION_BG"
+  elseif celebrationType == CelebrationType.Heist2 then
+    return "HEIST2_CELEBRATION", "HEIST2_CELEBRATION_FG", "HEIST2_CELEBRATION_BG"
+  end
+  return "", "", ""
+end
+
+---Create a new celebration wall
+function CelebrationInstance.New()
+  local data = {
+    _duration = 5000,
+    _scalformBackground = nil --[[@type Scaleform]],
+    _scalformForeground = nil --[[@type Scaleform]],
+    _scalformMain = nil --[[@type Scaleform]],
+  }
+  return setmetatable(data, CelebrationInstance)
+end
+
+---Load the celebration wall
+---@param celebrationType CelebrationType
+---@return promise<nil>
+function CelebrationInstance:Load(celebrationType)
+  local prom = promise.new()
+
+  local main, foreground, background = GetCelebrationScaleforms(celebrationType)
+
+  self._scalformBackground = Scaleform.Request(background)
+  self._scalformForeground = Scaleform.Request(foreground)
+  self._scalformMain = Scaleform.Request(main)
+
+  while not self._scalformBackground:IsLoaded() do
+    Citizen.Wait(0)
+  end
+
+  while not self._scalformForeground:IsLoaded() do
+    Citizen.Wait(0)
+  end
+
+  while not self._scalformMain:IsLoaded() do
+    Citizen.Wait(0)
+  end
+
+  prom:resolve()
+  return prom
+end
+
+---Call a function on all 3 scaleforms
+---@param ... any
+function CelebrationInstance:CallAllFunction(...)
+  self._scalformBackground:CallFunction(...)
+  self._scalformForeground:CallFunction(...)
+  self._scalformMain:CallFunction(...)
+end
+
+---Dispose the celebration wall
+function CelebrationInstance:Dispose()
+  self._scalformBackground:Dispose()
+  self._scalformBackground = nil
+  self._scalformForeground:Dispose()
+  self._scalformForeground = nil
+  self._scalformMain:Dispose()
+  self._scalformMain = nil
+end
+
+---Display the celebration wall for the duration of its animations, returns a promise that resolves when the animations are finished.
+---It is recommended to use this function instead of the manual display function as it will display the wall for the duration of its animations
+---and will resolve a promise when completed. Remember to clean up the wall after it is done displaying
+---using the Dispose function to prevent memory leaks or use the CleanUp function to clean up a set wall.
+---@return promise<nil>
+function CelebrationInstance:Display()
+  local prom = promise.new()
+
+  local startTime = GlobalGameTimer
+
+  local retHandle = self._scalformMain:CallFunction("GET_TOTAL_WALL_DURATION", true) or 0 --[[ @type number ]]
+
+  while not IsScaleformMovieMethodReturnValueReady(retHandle) do Wait(0) end
+  local time = GetScaleformMovieMethodReturnValueInt(retHandle)
+  local endTime = startTime + time
+
+  while GlobalGameTimer < endTime do
+    self._scalformBackground:Render2DMasked(self._scalformForeground);
+    self._scalformMain:Render2D()
+    Wait(0)
+  end
+
+  prom:resolve()
+  return prom
+end
+
+---Render the celebration wall manually
+function CelebrationInstance:ManualDisplay()
+  self._scalformBackground:Render2DMasked(self._scalformForeground);
+  self._scalformMain:Render2D()
+end
+
+---Clean up the wall and reset it
+function CelebrationInstance:CleanUp(wallId)
+  self:CallAllFunction("CLEANUP", false, { type = "playerNameComp", data = wallId })
+end
+
+---Create a stat wall
+---@param wallId string
+---@param colour string @Colours
+---@param foregroundAlpha string?
+---@see Colours
+function CelebrationInstance:CreateStatWall(wallId, colour, foregroundAlpha)
+  self:CallAllFunction("CREATE_STAT_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    { type = "playerNameComp", data = colour },
+    { type = "playerNameComp", data = foregroundAlpha or "100.0" }
+  )
+end
+
+---Add an intro to the wall
+---@param wallId string
+---@param modeLabel string
+---@param jobNameLabel string
+---@param challengeTextLabel string
+---@param challengePartsTextLabel string
+---@param targetTypeTextLabel string
+---@param targetValue string
+---@param delay number
+---@param targetValuePrefix string
+---@param modeLabelIsStringLiteral boolean
+---@param textColourName string
+function CelebrationInstance:AddIntroToWall(wallId, modeLabel, jobNameLabel, challengeTextLabel, challengePartsTextLabel,
+                                            targetTypeTextLabel, targetValue, delay, targetValuePrefix,
+                                            modeLabelIsStringLiteral,
+                                            textColourName)
+  local modeLabelType = "playerNameComp"
+  if modeLabelIsStringLiteral then
+    modeLabelType = "literal"
+  end
+
+  self:CallAllFunction("ADD_INTRO_TO_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    { type = modeLabelType, data = modeLabel },
+    { type = "label", data = jobNameLabel },
+    { type = "playerNameComp", data = challengeTextLabel },
+    { type = "label", data = challengePartsTextLabel },
+    { type = "playerNameComp", data = targetTypeTextLabel },
+    { type = "playerNameComp", data = targetValue },
+    delay,
+    { type = "playerNameComp", data = targetValuePrefix },
+    modeLabelIsStringLiteral,
+    { type = "playerNameComp", data = textColourName }
+  )
+end
+
+---Add a mission result to the wall
+---@param wallId string
+---@param missionTextLabel string
+---@param passFailTextLabel string
+---@param missionReasonString string
+---@param isReasonRawText boolean
+---@param isPassFailRawText boolean
+---@param isMissionTextRawText boolean
+---@param forcedAlpha number
+---@param hudColourId Colours
+---@see Colours
+function CelebrationInstance:AddMissionResultToWall(wallId, missionTextLabel, passFailTextLabel, missionReasonString,
+                                                    isReasonRawText, isPassFailRawText, isMissionTextRawText, forcedAlpha,
+                                                    hudColourId)
+  self:CallAllFunction("ADD_MISSION_RESULT_TO_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    { type = "playerNameComp", data = missionTextLabel },
+    { type = "playerNameComp", data = passFailTextLabel },
+    { type = "playerNameComp", data = missionReasonString },
+    isReasonRawText,
+    isPassFailRawText,
+    isMissionTextRawText,
+    forcedAlpha,
+    { type = "playerNameComp", data = hudColourId }
+  )
+end
+
+---Set the background texture of the wall
+---@param wallId string
+---@param alpha number
+---@param texture CelebrationTexture
+function CelebrationInstance:AddBackgroundToWall(wallId, alpha, texture)
+  self:CallAllFunction("ADD_BACKGROUND_TO_WALL", false, { type = "playerNameComp", data = wallId }, alpha, texture)
+end
+
+---Set which wall to show
+---@param wallId string
+function CelebrationInstance:ShowStatWall(wallId)
+  self:CallAllFunction("SHOW_STAT_WALL", false, { type = "playerNameComp", data = wallId })
+end
+
+---Set the pause duration
+---@param duration? number @Default: 3.0
+function CelebrationInstance:SetPauseDuration(duration)
+  self:CallAllFunction("SET_PAUSE_DURATION", false, duration or 3.0)
+end
+
+function CelebrationInstance:CreateBackgroundStatWall(wallId, colour, alpha)
+  self._scalformBackground:CallFunction("CREATE_STAT_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    { type = "playerNameComp", data = colour },
+    { type = "playerNameComp", data = alpha or "100.0" }
+  )
+end
+
+function CelebrationInstance:CreateForegroundStatWall(wallId, colour, alpha)
+  self._scalformForeground:CallFunction("CREATE_STAT_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    { type = "playerNameComp", data = colour },
+    { type = "playerNameComp", data = alpha or "100.0" }
+  )
+end
+
+function CelebrationInstance:CreateMainStatWall(wallId, colour, alpha)
+  self._scalformMain:CallFunction("CREATE_STAT_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    { type = "playerNameComp", data = colour },
+    { type = "playerNameComp", data = alpha or "100.0" }
+  )
+end
+
+---Set custom sounds for the wall
+---@param soundSet CelebrationCustomSounds
+---@see CelebrationCustomSounds
+function CelebrationInstance:SetCustomSound(soundSet)
+  self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
+    0,
+    { type = "literal", data = { "Blade_Appear", soundSet } }
+  )
+  self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
+    7,
+    { type = "literal", data = { "Blade_Beasts_Fail", soundSet } }
+  )
+  self._scalformMain:CallFunction("SET_CUSTOM_SOUND", false,
+    8,
+    { type = "literal", data = { "Blade_Beasts_Win", soundSet } }
+  )
+end
+
+---Add a winner to the wall
+---@param wallId string
+---@param winnLoseTextLabel string
+---@param gamerName string
+---@param crewName string
+---@param betAmount number
+---@param isInFlow boolean
+---@param teamName string
+---@param gamerNameIsLabel boolean
+function CelebrationInstance:AddWinnerToWall(wallId, winnLoseTextLabel, gamerName, crewName, betAmount, isInFlow,
+                                             teamName, gamerNameIsLabel)
+  self:CallAllFunction("ADD_WINNER_TO_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    { type = "playerNameComp", data = winnLoseTextLabel },
+    { type = "playerNameComp", data = gamerName },
+    { type = "playerNameComp", data = crewName },
+    { type = "playerNameComp", data = betAmount },
+    isInFlow,
+    { type = "playerNameComp", data = teamName },
+    gamerNameIsLabel
+  )
+end
+
+-- TODO: Investigate this function more
+---Add time to a wall
+---@param wallId string
+---@param time number @Time milliseconds
+---@param timeTitleLabel string @Time Label CELEB_TIME or CELEB_PERSONAL_BEST
+---@param timeDifference number @The time difference milliseconds
+function CelebrationInstance:AddTimeToWall(wallId, time, timeTitleLabel, timeDifference)
+  self:CallAllFunction("ADD_TIME_TO_WALL", false,
+    { type = "playerNameComp", data = wallId },
+    time,
+    { type = "playerNameString", data = timeTitleLabel },
+    timeDifference
+  )
+end

--- a/ScaleformUI_Lua/src/scaleforms/scaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/scaleform.lua
@@ -10,6 +10,7 @@ end
 ---@field public IsLoaded fun(self:Scaleform):boolean
 ---@field public IsValid fun(self:Scaleform):boolean
 ---@field public Render2D fun(self:Scaleform):nil
+---@field public Render2DMasked fun(self:Scaleform, scaleformToMask:Scaleform):nil
 ---@field public Render2DNormal fun(self:Scaleform, x:number, y:number, width:number, height:number):nil
 ---@field public Render3D fun(self:Scaleform, x:number, y:number, z:number, rx:number, ry:number, rz:number, scale:number):nil
 ---@field public Render3DAdditive fun(self:Scaleform, x:number, y:number, z:number, rx:number, ry:number, rz:number, scale:number):nil
@@ -61,16 +62,32 @@ function Scaleform:CallFunction(theFunction, returndata, ...)
                     ScaleformMovieMethodAddParamFloat(arg[i])
                 end
             elseif sType == "table" then
-                local type = arg[i].type
-                if type == "label" then
+                local tType = arg[i].type
+                if tType == "label" then
                     local label = arg[i].data
                     BeginTextCommandScaleformString(label)
                     EndTextCommandScaleformString() -- END_TEXT_COMMAND_SCALEFORM_STRING
-                elseif type == "literal" then
+                elseif tType == "literal" then
                     local label = arg[i].data
-                    ScaleformMovieMethodAddParamTextureNameString_2(label) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
+                    local labelType = type(label)
+
+                    if labelType == "table" then
+                        for lt = 1, #label do
+                            ScaleformMovieMethodAddParamTextureNameString_2(label[lt]) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
+                        end
+                    else
+                        ScaleformMovieMethodAddParamTextureNameString_2(label) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
+                    end
+                elseif tType == "playerNameComp" then
+                    local label = arg[i].data
+                    BeginTextCommandScaleformString("STRING")
+                    AddTextComponentSubstringPlayerName(label)
+                    EndTextCommandScaleformString()
+                elseif tType == "playerNameString" then
+                    local label = arg[i].data
+                    ScaleformMovieMethodAddParamPlayerNameString(label)
                 else
-                    assert(false, "^1ScaleformUI [ERROR]: ^7Unknown type ^1" .. type .. "^7.")
+                    assert(false, "^1ScaleformUI [ERROR]: ^7Unknown type ^1" .. tType .. "^7.")
                 end
             elseif sType == "string" then
                 if arg[i]:find("^desc_{") or arg[i]:find("^menu_lobby_desc_{") or arg[i]:find("^PauseMenu_") or arg[i]:find("^menu_pause_playerTab{") then
@@ -118,6 +135,11 @@ end
 ---Render the scaleform in 3D space with additive blending
 function Scaleform:Render3DAdditive(x, y, z, rx, ry, rz, scalex, scaley, scalez)
     DrawScaleformMovie_3d(self.handle, x, y, z, rx, ry, rz, 2.0, 2.0, 1.0, scalex, scaley, scalez, 2)
+end
+
+---Mask this scaleform with another scaleform full screen
+function Scaleform:Render2DMasked(scaleformToMask)
+    DrawScaleformMovieFullscreenMasked(self.handle, scaleformToMask.handle, 255, 255, 255, 255)
 end
 
 ---Disposes the scaleform

--- a/ScaleformUI_Lua/src/scaleforms/scaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/scaleform.lua
@@ -78,7 +78,7 @@ function Scaleform:CallFunction(theFunction, returndata, ...)
                     else
                         ScaleformMovieMethodAddParamTextureNameString_2(label) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
                     end
-                elseif tType == "playerNameComp" then
+                elseif tType == "playerName" then
                     local label = arg[i].data
                     BeginTextCommandScaleformString("STRING")
                     AddTextComponentSubstringPlayerName(label)

--- a/ScaleformUI_Lua/src/scaleforms/scaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/scaleform.lua
@@ -64,32 +64,16 @@ function Scaleform:CallFunction(theFunction, returndata, ...)
             elseif sType == "table" then
                 local tType = arg[i].type
                 if tType == "label" then
-                    local label = arg[i].data
-                    BeginTextCommandScaleformString(label)
-                    EndTextCommandScaleformString() -- END_TEXT_COMMAND_SCALEFORM_STRING
+                    BeginTextCommandScaleformString(arg[i].data)
+                    EndTextCommandScaleformString()                              -- END_TEXT_COMMAND_SCALEFORM_STRING
                 elseif tType == "literal" then
-                    local label = arg[i].data
-                    local labelType = type(label)
-
-                    if labelType == "table" then
-                        for lt = 1, #label do
-                            if type(lt) == "number" then
-                                ScaleformMovieMethodAddParamInt(label[lt])
-                            else
-                                ScaleformMovieMethodAddParamTextureNameString_2(label[lt]) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
-                            end
-                        end
-                    else
-                        ScaleformMovieMethodAddParamTextureNameString_2(label) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
-                    end
+                    ScaleformMovieMethodAddParamTextureNameString_2(arg[i].data) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
                 elseif tType == "playerNameComp" then
-                    local label = arg[i].data
                     BeginTextCommandScaleformString("STRING")
-                    AddTextComponentSubstringPlayerName(label)
+                    AddTextComponentSubstringPlayerName(arg[i].data)
                     EndTextCommandScaleformString()
                 elseif tType == "playerNameString" then
-                    local label = arg[i].data
-                    ScaleformMovieMethodAddParamPlayerNameString(label)
+                    ScaleformMovieMethodAddParamPlayerNameString(arg[i].data)
                 else
                     assert(false, "^1ScaleformUI [ERROR]: ^7Unknown type ^1" .. tType .. "^7.")
                 end

--- a/ScaleformUI_Lua/src/scaleforms/scaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/scaleform.lua
@@ -73,7 +73,11 @@ function Scaleform:CallFunction(theFunction, returndata, ...)
 
                     if labelType == "table" then
                         for lt = 1, #label do
-                            ScaleformMovieMethodAddParamTextureNameString_2(label[lt]) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
+                            if type(lt) == "number" then
+                                ScaleformMovieMethodAddParamInt(label[lt])
+                            else
+                                ScaleformMovieMethodAddParamTextureNameString_2(label[lt]) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
+                            end
                         end
                     else
                         ScaleformMovieMethodAddParamTextureNameString_2(label) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING

--- a/ScaleformUI_Lua/src/scaleforms/scaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/scaleform.lua
@@ -62,20 +62,19 @@ function Scaleform:CallFunction(theFunction, returndata, ...)
                     ScaleformMovieMethodAddParamFloat(arg[i])
                 end
             elseif sType == "table" then
-                local tType = arg[i].type
-                if tType == "label" then
+                if arg[i].type == "label" then
                     BeginTextCommandScaleformString(arg[i].data)
                     EndTextCommandScaleformString()                              -- END_TEXT_COMMAND_SCALEFORM_STRING
-                elseif tType == "literal" then
+                elseif arg[i].type == "literal" then
                     ScaleformMovieMethodAddParamTextureNameString_2(arg[i].data) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
-                elseif tType == "playerNameComp" then
+                elseif arg[i].type == "playerNameComp" then
                     BeginTextCommandScaleformString("STRING")
                     AddTextComponentSubstringPlayerName(arg[i].data)
                     EndTextCommandScaleformString()
-                elseif tType == "playerNameString" then
+                elseif arg[i].type == "playerNameString" then
                     ScaleformMovieMethodAddParamPlayerNameString(arg[i].data)
                 else
-                    assert(false, "^1ScaleformUI [ERROR]: ^7Unknown type ^1" .. tType .. "^7.")
+                    assert(false, "^1ScaleformUI [ERROR]: ^7Unknown type ^1" .. arg[i].type .. "^7.")
                 end
             elseif sType == "string" then
                 if arg[i]:find("^desc_{") or arg[i]:find("^menu_lobby_desc_{") or arg[i]:find("^PauseMenu_") or arg[i]:find("^menu_pause_playerTab{") then

--- a/ScaleformUI_Lua/src/scaleforms/scaleform.lua
+++ b/ScaleformUI_Lua/src/scaleforms/scaleform.lua
@@ -78,7 +78,7 @@ function Scaleform:CallFunction(theFunction, returndata, ...)
                     else
                         ScaleformMovieMethodAddParamTextureNameString_2(label) -- SCALEFORM_MOVIE_METHOD_ADD_PARAM_LITERAL_STRING
                     end
-                elseif tType == "playerName" then
+                elseif tType == "playerNameComp" then
                     local label = arg[i].data
                     BeginTextCommandScaleformString("STRING")
                     AddTextComponentSubstringPlayerName(label)

--- a/ScaleformUI_Lua/src/utils/Utils.lua
+++ b/ScaleformUI_Lua/src/utils/Utils.lua
@@ -1,5 +1,5 @@
 -- Globals
-GlobalGameTimer = GetGameTimer() --[[@type number]] -- GlobalGameTimer is used in many places, so we'll just define it here.
+GlobalGameTimer = GetGameTimer() --[[@type number]] -- GlobalGameTimer is used \in many places, so we'll just define it here.
 
 --Update GlobalGameTimer every 100ms, so we don't have to call GetGameTimer() every time we need it.
 Citizen.CreateThread(function()


### PR DESCRIPTION
Initial working out for the Celebration Scaleform, still to add some methods, committing back so nothing is lost and to start discussion on some method naming/controls. Once investigation in Lua is completed this will then be added to C#.

## Methds
- [x] SET_CUSTOM_SOUND
- [x] CREATE_STAT_WALL
- [ ] ADD_BREAKPOINT
- [ ] RESUME_FROM_BREAKPOINT
- [x] SET_PAUSE_DURATION
- [x] SHOW_STAT_WALL
- [ ] PAUSE_BEFORE_PREVIOUS_LAYOUT
- [ ] PAUSE
- [ ] UNPAUSE
- [ ] OVERRIDE_PAUSES
- [x] GET_TOTAL_WALL_DURATION
- [ ] SHOW_FLASH
- [x] CLEANUP
- [x] ADD_BACKGROUND_TO_WALL
- [ ] ADD_SCORE_TO_WALL
- [ ] ADD_POSITION_TO_WALL
- [ ] ADD_JOB_POINTS_TO_WALL
- [ ] ADD_ARENA_POINTS_TO_WALL
- [ ] ADD_POINTS_TO_WALL
- [ ] ADD_REP_POINTS_AND_RANK_BAR_TO_WALL
- [ ] ADD_ARENA_POINTS_AND_RANK_BAR_TO_WALL
- [x] ADD_WINNER_TO_WALL
- [ ] ADD_OBJECTIVE_TO_WALL
- [ ] ADD_ARENA_UNLOCK_TO_WALL
- [x] ADD_MISSION_RESULT_TO_WALL
- [x] ADD_TIME_TO_WALL
- [ ] ADD_CHALLENGE_SET_TO_WALL
- [ ] ADD_STAT_NUMERIC_TO_WALL
- [ ] ADD_CASH_WON_TO_WALL
- [ ] CREATE_INCREMENTAL_CASH_ANIMATION
- [ ] ADD_INCREMENTAL_CASH_WON_STEP
- [ ] ADD_INCREMENTAL_CASH_ANIMATION_TO_WALL
- [ ] ADD_WAVE_REACHED_TO_WALL
- [ ] ADD_WORLD_RECORD_TO_WALL
- [ ] ADD_TOURNAMENT_TO_WALL
- [x] ADD_INTRO_TO_WALL
- [x] ADD_READY_TO_WALL
- [x] ADD_CASH_TO_WALL
- [ ] ADD_CHALLENGE_PART_TO_WALL
- [ ] CREATE_STAT_TABLE
- [ ] ADD_STAT_TO_TABLE
- [ ] ADD_STAT_TABLE_TO_WALL
- [ ] ADD_CHALLENGE_WINNER_TO_WALL