### PR TITLE
Fix adding instructional buttons 

### DIFF
--- a/ScaleformUI_Lua/src/base/UIMenu.lua
+++ b/ScaleformUI_Lua/src/base/UIMenu.lua
@@ -1537,9 +1537,9 @@ function UIMenu:ProcessMouse()
 end
 
 ---AddInstructionButton
----@param button table
+---@param button InstructionalButton
 function UIMenu:AddInstructionButton(button)
-    if type(button) == "table" and #button == 2 then
+    if type(button) == "table" then
         self.InstructionalButtons[#self.InstructionalButtons + 1] = button
     end
 end


### PR DESCRIPTION
This feature was not working as if you pass an InstructionalButton.New(), the size is 0