### PR TITLE
Fix current index on UiMenu:Clear()

### DIFF
--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -1334,6 +1334,7 @@ namespace ScaleformUI.Menu
         /// </summary>
         public void Clear()
         {
+            Pagination.CurrentMenuIndex = value;
             MenuItems.Clear();
             Pagination.TotalItems = 0;
         }

--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -1334,7 +1334,7 @@ namespace ScaleformUI.Menu
         /// </summary>
         public void Clear()
         {
-            Pagination.CurrentMenuIndex = value;
+            Pagination.CurrentMenuIndex = 1;
             MenuItems.Clear();
             Pagination.TotalItems = 0;
         }

--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -1334,7 +1334,7 @@ namespace ScaleformUI.Menu
         /// </summary>
         public void Clear()
         {
-            Pagination.CurrentMenuIndex = 1;
+            Pagination.CurrentMenuIndex = 0;
             MenuItems.Clear();
             Pagination.TotalItems = 0;
         }

--- a/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
@@ -550,6 +550,7 @@ end
 
 ---Clear
 function UIMenu:Clear()
+    self.Pagination:CurrentMenuIndex(1)
     self.Items = {}
     self.Pagination:TotalItems(0)
     if self:Visible() then


### PR DESCRIPTION
Hello,
During the development on a project using the ScaleformUi, we use a submenu that have an dynamic size in each open. One time the number of element is 500 an another 300 , ... , ... And to make it we use the UiMenu:Clear() to clear the submenu and fill it with the new elements/items. But with that I notice that if I open the submenu with 500 items and put my current selection to 499 and back to the main menu and reopen it with 300 elements, it's not working and got an error because the currentselection stayed at 499 and is not reset by the Clear() that is not logical so I add it to the Clear() feature for UiMenu. For me, when we do a clear, we want to put the whole content of the menu at the initial state that means no item, current selection to 1. So I considerate it as a bug.

Thank to considerate it to fix it,
Zedsku