### PR TITLE
fix: bug in position and scale

### DIFF
--- a/ScaleformUI_Lua/src/scaleforms/Splash/SplashText.lua
+++ b/ScaleformUI_Lua/src/scaleforms/Splash/SplashText.lua
@@ -50,13 +50,13 @@ function SplashTextInstance:TransitionOut(duration, managed)
 end
 
 function SplashTextInstance:SetScale(width, height)
-  self.width = width;
-  self.height = height;
+  self._width = width;
+  self._height = height;
 end
 
 function SplashTextInstance:SetPosition(x, y)
-  self.x = x;
-  self.y = y;
+  self._posX = x;
+  self._posY = y;
 end
 
 function SplashTextInstance:Load()


### PR DESCRIPTION
```lua
local splashText = ScaleformUI.Scaleforms.SplashText;

splashText:Load():next(function()
    splashText:SetLabel("Hello World!", SColor.Violet, true);
  end,
  function(error)
    print("Error loading splash text: " .. error);
  end);

local count = 0;
local counter = 0;

math.randomseed(GetGameTimer())

CreateThread(function()
  while true do
    Wait(0);
    HideHudComponentThisFrame(14);
    SetScriptGfxDrawOrder(1);

    splashText:Draw();

    if count > 300 then
      splashText:SetTextLabel("Hello World! " .. tostring(counter), SColor.Violet);
      splashText:TransitionIn(300);
      count = 0
      counter = counter + 1;

      splashText:SetPosition(math.random(0, 100) / 100 + 0.0, math.random(0, 100) / 100 + 0.0);
      splashText:SetScale(math.random(0, 100) / 100 + 0.0, math.random(0, 100) / 100 + 0.0);
    end

    count = count + 1;

    if IsControlJustPressed(0, 38) then
      splashText:TransitionIn();
    end

    if IsControlJustPressed(0, 23) then
      splashText:TransitionOut(300);
    end
  end
end)
```