### PR TITLE
UIMenuItem Highlighted event

### DIFF
--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
@@ -326,6 +326,11 @@ namespace ScaleformUI.Menu
         /// Called when user selects the current item.
         /// </summary>
         public event ItemActivatedEvent Activated;
+        
+        /// <summary>
+        /// Called when user changes items in the menu and this item becomes selected.
+        /// </summary>
+        public event ItemSelectedEvent OnSelect;
 
 
         /// <summary>
@@ -433,6 +438,7 @@ namespace ScaleformUI.Menu
                         _formatRightLabel = _formatRightLabel.Replace("~w~", "~l~");
                         _formatRightLabel = _formatRightLabel.Replace("~s~", "~l~");
                     }
+                    OnSelect?.Invoke(Parent, this);
                 }
                 else
                 {

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
@@ -328,10 +328,9 @@ namespace ScaleformUI.Menu
         public event ItemActivatedEvent Activated;
         
         /// <summary>
-        /// Called when user changes items in the menu and this item becomes selected.
+        /// Called when user "highlights" the current item.
         /// </summary>
-        public event ItemSelectedEvent OnSelect;
-
+        public event ItemHighlightedEvent Highlighted;
 
         /// <summary>
         /// Basic menu button.
@@ -438,7 +437,7 @@ namespace ScaleformUI.Menu
                         _formatRightLabel = _formatRightLabel.Replace("~w~", "~l~");
                         _formatRightLabel = _formatRightLabel.Replace("~s~", "~l~");
                     }
-                    OnSelect?.Invoke(Parent, this);
+                    Highlighted?.Invoke(Parent, this);
                 }
                 else
                 {

--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -812,6 +812,7 @@ namespace ScaleformUI.Menu
     public delegate void GridPanelChangedEvent(UIMenuItem menu, UIMenuGridPanel panel, PointF value);
     public delegate void MenuOpenedEvent(UIMenu menu, dynamic data = null);
     public delegate void MenuClosedEvent(UIMenu menu);
+    public delegate void ItemSelectedEvent(UIMenu menu, UIMenuItem item);
 
     public enum MenuAnimationType
     {

--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -812,7 +812,7 @@ namespace ScaleformUI.Menu
     public delegate void GridPanelChangedEvent(UIMenuItem menu, UIMenuGridPanel panel, PointF value);
     public delegate void MenuOpenedEvent(UIMenu menu, dynamic data = null);
     public delegate void MenuClosedEvent(UIMenu menu);
-    public delegate void ItemSelectedEvent(UIMenu menu, UIMenuItem item);
+    public delegate void ItemHighlightedEvent(UIMenu menu, UIMenuItem item);
 
     public enum MenuAnimationType
     {

--- a/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuItem.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuItem.lua
@@ -74,7 +74,9 @@ function UIMenuItem.New(text, description, color, highlightColor, textColor, hig
         SidePanel = nil,
         ItemId = 0,
         Activated = function(menu, item)
-        end
+        end,
+        OnSelect = function(menu, item)
+        end,
     }
     return setmetatable(_UIMenuItem, UIMenuItem)
 end
@@ -156,6 +158,7 @@ function UIMenuItem:Selected(bool, item)
                 self._formatRightLabel = self._formatRightLabel:gsub("~w~", "~l~")
                 self._formatRightLabel = self._formatRightLabel:gsub("~s~", "~l~")
             end
+            self.OnSelect(self.ParentMenu, item)
         else
             self._formatLeftLabel = self._formatLeftLabel:gsub("~l~", "~s~")
             if not string.IsNullOrEmpty(self._formatRightLabel) then

--- a/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuItem.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuItem.lua
@@ -75,7 +75,7 @@ function UIMenuItem.New(text, description, color, highlightColor, textColor, hig
         ItemId = 0,
         Activated = function(menu, item)
         end,
-        OnSelect = function(menu, item)
+        Highlighted = function(menu, item)
         end,
     }
     return setmetatable(_UIMenuItem, UIMenuItem)
@@ -158,7 +158,7 @@ function UIMenuItem:Selected(bool, item)
                 self._formatRightLabel = self._formatRightLabel:gsub("~w~", "~l~")
                 self._formatRightLabel = self._formatRightLabel:gsub("~s~", "~l~")
             end
-            self.OnSelect(self.ParentMenu, item)
+            self.Highlighted(self.ParentMenu, item)
         else
             self._formatLeftLabel = self._formatLeftLabel:gsub("~l~", "~s~")
             if not string.IsNullOrEmpty(self._formatRightLabel) then


### PR DESCRIPTION
This implements a new event `Highlighted` which will be triggered when the item is "selected".

Lua Example:
```lua
    local dummyItem = UIMenuItem.New("Dummy Item", "Dummy Item")

    dummyItem.Highlighted = function (item)
        print('Dummy Item Highlighted')
    end
```

C# Example:
```csharp
        UIMenu exampleMenu = new UIMenu("ScaleformUI", "ScaleformUI ~o~SHOWCASE", new PointF(20, 20), "scaleformui", "bannerbackground", true, true);

        UIMenuItem exampleItem = new UIMenuItem("Example Item", "This is an example item.");

        exampleItem.Highlighted += (menu, item) => {
            Debug.WriteLine("Example Item Highlighted");
        };
```
