### PR TITLE
feat(goback) : add optional parameter to allow bypassing CanPlayerCloseMenu condition

### DIFF
--- a/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
@@ -1221,14 +1221,15 @@ end
 
 ---Go back to the previous menu
 ---@param boolean boolean? Play sound
-function UIMenu:GoBack(boolean)
+---@param bypass boolean? Bypass the CanPlayerCloseMenu condition
+function UIMenu:GoBack(boolean, bypass)
     local playSound = true
 
     if type(boolean) == "boolean" then
         playSound = boolean
     end
 
-    if self:CanPlayerCloseMenu() then
+    if self:CanPlayerCloseMenu() or bypass then
         self:FadeOutMenu()
         if playSound then
             PlaySoundFrontend(-1, self.Settings.Audio.Back, self.Settings.Audio.Library, true)


### PR DESCRIPTION
I found it useful for some menu that a player can't close unless pressing a "confirm" button, that triggers some events + goes back to previous menu