### PR TITLE
Handle filtering fail (no match found)

### DIFF
--- a/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
@@ -1011,7 +1011,7 @@ function UIMenu:_itemCreation(page, pageIndex, before, overflow)
     end
 end
 
-function UIMenu:FilterMenuItems(predicate)
+function UIMenu:FilterMenuItems(predicate, fail)
     assert(not self._itemless, "ScaleformUI - You can't compare or sort an itemless menu")
     self.Items[self:CurrentSelection()]:Selected(false)
     if self._unfilteredMenuItems == nil or #self._unfilteredMenuItems == 0 then
@@ -1022,6 +1022,14 @@ function UIMenu:FilterMenuItems(predicate)
         if predicate(item) then
             table.insert(self.Items, item)
         end
+    end
+    if #self.Items == 0 then
+        self:Clear()
+        self.Items = self._unfilteredMenuItems
+        self.Pagination:TotalItems(#self.Items)
+        self:BuildUpMenuAsync(true)
+        fail()
+        return
     end
     self.Pagination:TotalItems(#self.Items)
     self:BuildUpMenuAsync(true)


### PR DESCRIPTION
handle filter fail (led to empty menu and crashing the menu) + allow user to set a function on filtering fail
Fail function can be useful to notify the user that the filter failed, and the menu shows the default items