### PR TITLE
Fix GlobalGameTimer in Lua

### DIFF
--- a/ScaleformUI_Lua/src/utils/Utils.lua
+++ b/ScaleformUI_Lua/src/utils/Utils.lua
@@ -1,5 +1,5 @@
 -- Globals
-GlobalGameTimer = GetGameTimer() --[[@type number]] -- GlobalGameTimer is used in many places, so we'll just define it here.
+GlobalGameTimer = GetNetworkTime() --[[@type number]] -- GlobalGameTimer is used in many places, so we'll just define it here.
 
 -- Make the number type detected as integer to avoid multiple lint detections.
 ---@diagnostic disable-next-line: duplicate-doc-alias


### PR DESCRIPTION
The fix is to start `GlobalGameTimer` with **network** time instead of **game** time.

Currently, it starts as `GetGameTimer()` and later gets updated to `GetNetworkTime()` every 100ms.

This causes problems in the MultiplayerChat component (in the Update function), as it checks if the component started more than 10000ms ago to close it automatically. However, due to the difference between these two times, it closes instantly.