### PR TITLE
Add `SetMenuOffset` method

### DIFF
--- a/MenuExample/MenuExample.cs
+++ b/MenuExample/MenuExample.cs
@@ -400,6 +400,38 @@ public class MenuExample : BaseScript
         exampleMenu.AddItem(ResetFiltering);
 
         #endregion
+        
+        #region Offset Changer
+        UIMenuItem offsetItem = new UIMenuItem("Change Offset", "Change the offset of the menu");
+        offsetItem.SetRightLabel(">>>");
+        exampleMenu.AddItem(offsetItem);
+        
+        UIMenu offsetMenu = new UIMenu("Offset Menu", "Change the offset of the menu");
+        UIMenuDynamicListItem offsetX = new UIMenuDynamicListItem("Offset X", "Change the X offset of the menu", exampleMenu.Offset.X.ToString("F3"), async (sender, direction) =>
+        {
+            if (direction == ChangeDirection.Left) exampleMenu.SetMenuOffset(new PointF(exampleMenu.Offset.X - 1f, exampleMenu.Offset.Y));
+            else exampleMenu.SetMenuOffset(new PointF(exampleMenu.Offset.X + 1f, exampleMenu.Offset.Y));
+            exampleMenu.RefreshMenu();
+            return exampleMenu.Offset.X.ToString("F3");
+        });
+        
+        UIMenuDynamicListItem offsetY = new UIMenuDynamicListItem("Offset Y", "Change the Y offset of the menu", exampleMenu.Offset.Y.ToString("F3"), async (sender, direction) =>
+        {
+            if (direction == ChangeDirection.Left) exampleMenu.SetMenuOffset(new PointF(exampleMenu.Offset.X, exampleMenu.Offset.Y - 1f));
+            else exampleMenu.SetMenuOffset(new PointF(exampleMenu.Offset.X, exampleMenu.Offset.Y + 1f));
+            exampleMenu.RefreshMenu();
+            return exampleMenu.Offset.Y.ToString("F3");
+        });
+        
+        offsetMenu.AddItem(offsetX);
+        offsetMenu.AddItem(offsetY);
+        
+        offsetItem.Activated += (sender, args) =>
+        {
+            sender.SwitchTo(offsetMenu, inheritOldMenuParams: true);
+        };
+        #endregion
+        
 
         #endregion
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -1661,7 +1661,6 @@ namespace ScaleformUI.Menu
                 _menuGlare.CallFunction("SET_DATA_SLOT", GameplayCamera.RelativeHeading);
                 SizeF _glareSize = new SizeF(1f, 1f);
                 PointF gl = new PointF((Offset.X / Screen.Width) + 0.4499f, (Offset.Y / Screen.Height) + 0.454f);
-
                 DrawScaleformMovie(_menuGlare.Handle, gl.X, gl.Y, _glareSize.Width, _glareSize.Height, 255, 255, 255, 255, 0);
             }
 
@@ -2894,6 +2893,17 @@ namespace ScaleformUI.Menu
         {
             get => MenuItems[CurrentSelection];
             set => CurrentSelection = MenuItems.Any(x => x.Label == value.Label && x.Description == value.Description) ? MenuItems.IndexOf(value) : 0;
+        }
+        
+        
+        /// <summary>
+        ///  Set's the menus offset after initialization.
+        /// </summary>
+        /// <param name="offset"></param>
+        public void SetMenuOffset(PointF offset)
+        {
+            Offset = offset;
+            Main.scaleformUI.CallFunction("SET_MENU_OFFSET", Offset.X, Offset.Y);
         }
 
         /// <summary>


### PR DESCRIPTION
Adds a new method which allows for changing the menu offset after menu init along with a example menu.

TODO:
* Fix the glare not changing offset
* Add Lua method

Relevant Scaleform PR: https://github.com/manups4e/ScaleformUI-Scaleform/pull/1
