### PR TITLE
ScaleformUI - Update 3: Make FiveM Great Again - Part 1

### DIFF
--- a/MenuExample/MenuExample.cs
+++ b/MenuExample/MenuExample.cs
@@ -48,7 +48,6 @@ public class MenuExample : BaseScript
         #region Big Message
 
         UIMenuItem bigMessageItem = new UIMenuItem("~g~Big~s~ Message ~r~Examples~s~", "Select me to switch to the BigMessage menu!");
-        bigMessageItem.SetRightLabel("test");
         bigMessageItem.SetCustomLeftBadge("scaleformui", "kitty");
         bigMessageItem.SetCustomRightBadge("scaleformui", "kitty");
 

--- a/MenuExample/MenuExample.cs
+++ b/MenuExample/MenuExample.cs
@@ -415,6 +415,7 @@ public class MenuExample : BaseScript
         align.OnListChanged += (item, index) => 
         { 
             item.Parent.MenuAlignment = (MenuAlignment)index; 
+            exampleMenu.MenuAlignment = (MenuAlignment)index;
         };
 
         UIMenuDynamicListItem offsetX = new UIMenuDynamicListItem("Offset X", "Change the X offset of the menu", exampleMenu.Offset.X.ToString("F3"), async (sender, direction) =>

--- a/MenuExample/MenuExample.cs
+++ b/MenuExample/MenuExample.cs
@@ -37,9 +37,8 @@ public class MenuExample : BaseScript
 
         // first true means add menu Glare scaleform to the menu
         // last true means it's using the alternative title style
-        UIMenu exampleMenu = new UIMenu("ScaleformUI", "ScaleformUI ~o~SHOWCASE", new PointF(0, 0), "commonmenu", "interaction_bgd", true, true, 0f, MenuAlignment.RIGHT);
+        UIMenu exampleMenu = new UIMenu("ScaleformUI", "ScaleformUI ~o~SHOWCASE", new PointF(0, 0), "commonmenu", "interaction_bgd", true, true, MenuAlignment.RIGHT);
         exampleMenu.MaxItemsOnScreen = 7; // To decide max items on screen at time, default 7
-        exampleMenu.SetAnimations(true, true, MenuAnimationType.LINEAR, MenuBuildingAnimation.LEFT_RIGHT);
         exampleMenu.SetMouse(false, false, false, false, false);
 
         //exampleMenu.CounterColor = HudColor.HUD_COLOUR_PINK;
@@ -49,6 +48,7 @@ public class MenuExample : BaseScript
         #region Big Message
 
         UIMenuItem bigMessageItem = new UIMenuItem("~g~Big~s~ Message ~r~Examples~s~", "Select me to switch to the BigMessage menu!");
+        bigMessageItem.SetRightLabel("test");
         bigMessageItem.SetCustomLeftBadge("scaleformui", "kitty");
         bigMessageItem.SetCustomRightBadge("scaleformui", "kitty");
 
@@ -229,10 +229,6 @@ public class MenuExample : BaseScript
         UIMenuSeparatorItem BlankItem_2 = new UIMenuSeparatorItem("Separator (not Jumped)", false);
         exampleMenu.AddItem(BlankItem);
         exampleMenu.AddItem(BlankItem_2);
-
-        UIMenuListItem colorListItem = new UIMenuListItem("Choose the scrolling animation", foodsList, (int)exampleMenu.AnimationType, "~BLIP_BARBER~ ~BLIP_INFO_ICON~ ~BLIP_TANK~ ~BLIP_OFFICE~ ~BLIP_CRIM_DRUGS~ ~BLIP_WAYPOINT~ ~INPUTGROUP_MOVE~~n~You can use Blips and Inputs in description as you prefer!~n~⚠ 🐌 ❤️ 🥺 💪🏻 You can use Emojis too!", SColor.HUD_Freemode_dark, SColor.HUD_Freemode);
-        colorListItem.BlinkDescription = true;
-        exampleMenu.AddItem(colorListItem);
 
         UIMenuSliderItem slider = new UIMenuSliderItem("Slider Item", "Cool!", true); // by default max is 100 and multipler 5 = 20 steps.
         exampleMenu.AddItem(slider);
@@ -995,8 +991,6 @@ public class MenuExample : BaseScript
             if (item == ketchupItem)
             {
                 enabled = checked_;
-                sender.EnableAnimation = enabled;
-                colorListItem.Enabled = enabled;
                 Notifications.ShowNotification("~r~Menu animation: ~b~" + (enabled ? "Enabled" : "Disabled"));
             }
         };
@@ -1014,12 +1008,6 @@ public class MenuExample : BaseScript
         {
             //if (sender.MenuItems[index] == cookItem)
             //cookItem.SetLeftBadge(BadgeIcon.NONE);
-        };
-
-        exampleMenu.OnListChange += (sender, item, index) =>
-        {
-            if (item == colorListItem)
-                sender.AnimationType = (MenuAnimationType)index;
         };
 
         exampleMenu.OnMenuOpen += (menu, data) =>

--- a/MenuExample/MenuExample.cs
+++ b/MenuExample/MenuExample.cs
@@ -37,16 +37,14 @@ public class MenuExample : BaseScript
 
         // first true means add menu Glare scaleform to the menu
         // last true means it's using the alternative title style
-        UIMenu exampleMenu = new UIMenu("ScaleformUI", "ScaleformUI ~o~SHOWCASE", new PointF(20, 20), "commonmenu", "interaction_bgd", true, true, MenuAlignment.RIGHT);
-        exampleMenu.MaxItemsOnScreen = 15; // To decide max items on screen at time, default 7
+        UIMenu exampleMenu = new UIMenu("ScaleformUI", "ScaleformUI ~o~SHOWCASE", new PointF(376, 50), "commonmenu", "interaction_bgd", true, true, MenuAlignment.RIGHT);
+        exampleMenu.MaxItemsOnScreen = 7; // To decide max items on screen at time, default 7
         exampleMenu.SetMouse(true, false, true, false, false);
 
         //exampleMenu.CounterColor = HudColor.HUD_COLOUR_PINK;
         // let's add the menu to the Pool
         #region Menu Declaration
 
-        UIMenuSeparatorItem separatorJ = new UIMenuSeparatorItem("separator 1", true);
-        exampleMenu.AddItem(separatorJ);
         #region Big Message
 
         UIMenuItem bigMessageItem = new UIMenuItem("~g~Big~s~ Message ~r~Examples~s~", "Select me to switch to the BigMessage menu!");
@@ -149,9 +147,6 @@ public class MenuExample : BaseScript
         };
 
         #endregion
-
-        UIMenuSeparatorItem separatorJ2 = new UIMenuSeparatorItem("separator 2", true);
-        exampleMenu.AddItem(separatorJ2);
 
         UIMenuCheckboxItem ketchupItem = new UIMenuCheckboxItem("~g~Scrolling animation enabled? ~b~in a very long label to ~o~test the text scrolling feature!", UIMenuCheckboxStyle.Tick, enabled, "Do you wish to enable the scrolling animation?");
         long _paneldui = API.CreateDui("https://i.imgur.com/mH0Y65C.gif", 288, 160);
@@ -275,6 +270,22 @@ public class MenuExample : BaseScript
         statistics.UpdateStatistic(0, 10f);
         statistics.UpdateStatistic(1, 50f);
         statistics.UpdateStatistic(2, 100f);
+        listPanelItem4.OnListChanged += (a, b) =>
+        {
+            switch (b)
+            {
+                case 0:
+                    statistics.UpdateStatistic(0, 10f);
+                    statistics.UpdateStatistic(1, 50f);
+                    statistics.UpdateStatistic(2, 100f);
+                    break;
+                case 1:
+                    statistics.UpdateStatistic(0, 100f);
+                    statistics.UpdateStatistic(1, 50f);
+                    statistics.UpdateStatistic(2, 10f);
+                    break;
+            }
+        };
         //and you can get / set their percentage
 
 

--- a/MenuExample/MenuExample.cs
+++ b/MenuExample/MenuExample.cs
@@ -37,7 +37,7 @@ public class MenuExample : BaseScript
 
         // first true means add menu Glare scaleform to the menu
         // last true means it's using the alternative title style
-        UIMenu exampleMenu = new UIMenu("ScaleformUI", "ScaleformUI ~o~SHOWCASE", new PointF(0, 0), "commonmenu", "interaction_bgd", true, true, MenuAlignment.RIGHT);
+        UIMenu exampleMenu = new UIMenu("ScaleformUI", "ScaleformUI ~o~SHOWCASE", new PointF(20, 20), "commonmenu", "interaction_bgd", true, true, MenuAlignment.RIGHT);
         exampleMenu.MaxItemsOnScreen = 7; // To decide max items on screen at time, default 7
         exampleMenu.SetMouse(true, false, true, false, false);
 
@@ -992,6 +992,8 @@ public class MenuExample : BaseScript
             if (item == ketchupItem)
             {
                 enabled = checked_;
+                scrollType.Enabled = checked_;
+                scrollType.SetLeftBadge(checked_ ? BadgeIcon.NONE : BadgeIcon.LOCK);
                 Notifications.ShowNotification("~r~Menu animation: ~b~" + (enabled ? "Enabled" : "Disabled"));
             }
         };

--- a/MenuExample/MenuExample.cs
+++ b/MenuExample/MenuExample.cs
@@ -38,13 +38,15 @@ public class MenuExample : BaseScript
         // first true means add menu Glare scaleform to the menu
         // last true means it's using the alternative title style
         UIMenu exampleMenu = new UIMenu("ScaleformUI", "ScaleformUI ~o~SHOWCASE", new PointF(20, 20), "commonmenu", "interaction_bgd", true, true, MenuAlignment.RIGHT);
-        exampleMenu.MaxItemsOnScreen = 7; // To decide max items on screen at time, default 7
+        exampleMenu.MaxItemsOnScreen = 15; // To decide max items on screen at time, default 7
         exampleMenu.SetMouse(true, false, true, false, false);
 
         //exampleMenu.CounterColor = HudColor.HUD_COLOUR_PINK;
         // let's add the menu to the Pool
         #region Menu Declaration
 
+        UIMenuSeparatorItem separatorJ = new UIMenuSeparatorItem("separator 1", true);
+        exampleMenu.AddItem(separatorJ);
         #region Big Message
 
         UIMenuItem bigMessageItem = new UIMenuItem("~g~Big~s~ Message ~r~Examples~s~", "Select me to switch to the BigMessage menu!");
@@ -147,6 +149,9 @@ public class MenuExample : BaseScript
         };
 
         #endregion
+
+        UIMenuSeparatorItem separatorJ2 = new UIMenuSeparatorItem("separator 2", true);
+        exampleMenu.AddItem(separatorJ2);
 
         UIMenuCheckboxItem ketchupItem = new UIMenuCheckboxItem("~g~Scrolling animation enabled? ~b~in a very long label to ~o~test the text scrolling feature!", UIMenuCheckboxStyle.Tick, enabled, "Do you wish to enable the scrolling animation?");
         long _paneldui = API.CreateDui("https://i.imgur.com/mH0Y65C.gif", 288, 160);
@@ -287,12 +292,13 @@ public class MenuExample : BaseScript
         windowSubmenu.AddWindow(statsWindow);
         List<dynamic> momfaces = new List<dynamic>() { "Hannah", "Audrey", "Jasmine", "Giselle", "Amelia", "Isabella", "Zoe", "Ava", "Camilla", "Violet", "Sophia", "Eveline", "Nicole", "Ashley", "Grace", "Brianna", "Natalie", "Olivia", "Elizabeth", "Charlotte", "Emma", "Misty" };
         List<dynamic> dadfaces = new List<dynamic>() { "Benjamin", "Daniel", "Joshua", "Noah", "Andrew", "Joan", "Alex", "Isaac", "Evan", "Ethan", "Vincent", "Angel", "Diego", "Adrian", "Gabriel", "Michael", "Santiago", "Kevin", "Louis", "Samuel", "Anthony", "Claude", "Niko", "John" };
-        UIMenuListItem mom = new UIMenuListItem("Mamma", momfaces, 0);
-        UIMenuListItem dad = new UIMenuListItem("Papà", dadfaces, 0);
+        UIMenuListItem mom = new UIMenuListItem("Mom", momfaces, 0);
+        UIMenuListItem dad = new UIMenuListItem("Dad", dadfaces, 0);
         UIMenuSliderItem newItem = new UIMenuSliderItem("Heritage Slider", "This is Useful on heritage", 100, 5, 50, true);
         windowSubmenu.AddItem(mom);
         windowSubmenu.AddItem(dad);
         windowSubmenu.AddItem(newItem);
+
         statsWindow.DetailMid = "Dad: " + newItem.Value + "%";
         statsWindow.DetailBottom = "Mom: " + (100 - newItem.Value) + "%";
         statsWindow.DetailStats = new List<UIDetailStat>()

--- a/MenuExample/MenuExample.cs
+++ b/MenuExample/MenuExample.cs
@@ -29,7 +29,7 @@ public class MenuExample : BaseScript
     #region UIMenu
     public async void ExampleMenu()
     {
-        long _titledui = API.CreateDui("https://i.imgur.com/3yrFYbF.gif", 288, 130);
+        long _titledui = API.CreateDui("https://media.tenor.com/-sL5lSwzQSkAAAAi/rolling-cute.gif", 288, 130);
         API.CreateRuntimeTextureFromDuiHandle(txd, "bannerbackground", API.GetDuiHandle(_titledui));
 
         long _kitten = API.CreateDui("https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExczA0dXhscDRqbHBmb3I2bmk4dDVzd25uNmhhbHNmMnE5N3hkYTM0MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tY27Dk0H8IisGidQv6/giphy.gif", 480, 480);
@@ -39,7 +39,7 @@ public class MenuExample : BaseScript
         // last true means it's using the alternative title style
         UIMenu exampleMenu = new UIMenu("ScaleformUI", "ScaleformUI ~o~SHOWCASE", new PointF(0, 0), "commonmenu", "interaction_bgd", true, true, MenuAlignment.RIGHT);
         exampleMenu.MaxItemsOnScreen = 7; // To decide max items on screen at time, default 7
-        exampleMenu.SetMouse(false, false, false, false, false);
+        exampleMenu.SetMouse(true, false, true, false, false);
 
         //exampleMenu.CounterColor = HudColor.HUD_COLOUR_PINK;
         // let's add the menu to the Pool
@@ -152,7 +152,7 @@ public class MenuExample : BaseScript
         UIMenuCheckboxItem ketchupItem = new UIMenuCheckboxItem("~g~Scrolling animation enabled? ~b~in a very long label to ~o~test the text scrolling feature!", UIMenuCheckboxStyle.Tick, enabled, "Do you wish to enable the scrolling animation?");
         long _paneldui = API.CreateDui("https://i.imgur.com/mH0Y65C.gif", 288, 160);
         API.CreateRuntimeTextureFromDuiHandle(txd, "panelbackground", API.GetDuiHandle(_paneldui));
-        UIMissionDetailsPanel sidePanel = new UIMissionDetailsPanel(PanelSide.Right, "Side Panel", true, "scaleformui", "panelbackground");
+        UIMissionDetailsPanel sidePanel = new UIMissionDetailsPanel(PanelSide.Right, "Side Panel", true, "scaleformui", "bannerbackground");
         UIFreemodeDetailsItem detailItem1 = new UIFreemodeDetailsItem("Left Label", "RIGHT LABEL", ScaleformFonts.SIGNPAINTER_HOUSESCRIPT, ScaleformFonts.GTAV_TAXI_DIGITAL, BadgeIcon.BRIEFCASE, SColor.FromRandomValues());
         UIFreemodeDetailsItem detailItem2 = new UIFreemodeDetailsItem("Left Label", "RIGHT LABEL", ScaleformFonts.SIGNPAINTER_HOUSESCRIPT, ScaleformFonts.GTAV_TAXI_DIGITAL, BadgeIcon.MISSION_STAR, SColor.FromRandomValues());
         UIFreemodeDetailsItem detailItem3 = new UIFreemodeDetailsItem("Left Label", "RIGHT LABEL", ScaleformFonts.SIGNPAINTER_HOUSESCRIPT, ScaleformFonts.GTAV_TAXI_DIGITAL, BadgeIcon.ARMOR, SColor.FromRandomValues());

--- a/ScaleformUI_Csharp/Elements/ScreenTools.cs
+++ b/ScaleformUI_Csharp/Elements/ScreenTools.cs
@@ -76,7 +76,7 @@ namespace ScaleformUI.Elements
             // Normalize coordinates to 0.0 - 1.0 range
             int w = 0, h = 0;
             GetActiveScreenResolution(ref w, ref h);
-            return new Vector2((scaleformX / w) * 2f - 1f, (scaleformY / h) * 2f - 1f);
+            return new Vector2(scaleformX / w, scaleformY / h);
         }
 
         public static Vector2 ConvertResolutionCoordsToScreenCoords(float x, float y)
@@ -85,6 +85,21 @@ namespace ScaleformUI.Elements
             float normalizedY = Math.Max(0.0f, Math.Min(1.0f, (float)y / 1080.0f));
 
             return new Vector2(normalizedX, normalizedY);
+        }
+
+
+        /// <summary>
+        /// Converts scaleform size(1280 x 720) into screen size(0.0 - 1.0)
+        /// </summary>
+        /// <param name="scaleformWidth"></param>
+        /// <param name="scaleformHeight"></param>
+        /// <returns></returns>
+        public static SizeF ConvertScaleformSizeToScreenSize(float scaleformWidth, float scaleformHeight)
+        {
+            //Normalize size to 0.0 - 1.0 range
+            int w = 0, h = 0;
+            GetActiveScreenResolution(ref w, ref h);
+            return new SizeF(scaleformWidth / w, scaleformHeight / h);
         }
 
         public static void AdjustNormalized16_9ValuesForCurrentAspectRatio(int widescreen, ref Vector2 pos, ref SizeF size)

--- a/ScaleformUI_Csharp/Menus/MenuBase.cs
+++ b/ScaleformUI_Csharp/Menus/MenuBase.cs
@@ -16,7 +16,7 @@ namespace ScaleformUI.Menus
             }
         }
         public List<InstructionalButton> InstructionalButtons { get; set; }
-        internal virtual void ProcessControl(Keys key = Keys.None)
+        internal virtual void ProcessControl()
         {
 
         }

--- a/ScaleformUI_Csharp/Menus/MenuHandler.cs
+++ b/ScaleformUI_Csharp/Menus/MenuHandler.cs
@@ -64,7 +64,6 @@ namespace ScaleformUI
 
             if (currentMenu is UIMenu old)
             {
-                await old.FadeOutMenu();
                 currentMenu.Visible = false;
                 if (newMenu is UIMenu newer)
                 {
@@ -79,9 +78,7 @@ namespace ScaleformUI
                         newer.MaxItemsOnScreen = old.MaxItemsOnScreen;
                         newer.ScrollingType = old.ScrollingType;
                         newer.Glare = old.Glare;
-                        newer.fadingTime = old.fadingTime;
                         newer.SetMouse(old.MouseControlsEnabled, old.MouseEdgeEnabled, old.MouseWheelControlEnabled, old.ResetCursorOnOpen, old.leftClickEnabled);
-                        newer.SetAnimations(old.EnableAnimation, old.Enabled3DAnimations, old.AnimationType, old.BuildingAnimation);
                         newer.SubtitleColor = old.SubtitleColor;
                     }
                     newer.CurrentSelection = newMenuCurrentSelection != 0 ? newMenuCurrentSelection : 0;

--- a/ScaleformUI_Csharp/Menus/Pause Menus/Elements/Columns/SettingsListColumn.cs
+++ b/ScaleformUI_Csharp/Menus/Pause Menus/Elements/Columns/SettingsListColumn.cs
@@ -125,8 +125,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(it.Index);
                         PushScaleformMovieFunctionParameterInt(it.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(it.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(it.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(it.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     case UIMenuCheckboxItem:
@@ -135,8 +135,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieMethodParameterBool(check.Checked);
                         PushScaleformMovieFunctionParameterInt(check.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(check.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(check.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(check.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     case UIMenuSliderItem:
@@ -146,8 +146,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(prItem.Value);
                         PushScaleformMovieFunctionParameterInt(prItem.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(prItem.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(prItem.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(prItem.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(prItem.SliderColor.ArgbValue);
                         PushScaleformMovieFunctionParameterBool(prItem._heritage);
                         EndScaleformMovieMethod();
@@ -159,8 +159,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(slItem.Value);
                         PushScaleformMovieFunctionParameterInt(slItem.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(slItem.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(slItem.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(slItem.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(slItem.SliderColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
@@ -169,15 +169,15 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterBool(separatorItem.Jumpable);
                         PushScaleformMovieFunctionParameterInt(item.MainColor.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(item.HighlightColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     default:
                         PushScaleformMovieFunctionParameterInt(item.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(item.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         EndScaleformMovieMethod();
                         lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL_RIGHT", scaleformIndex, item._formatRightLabel);
                         if (item.RightBadge != BadgeIcon.NONE)
@@ -223,8 +223,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(it.Index);
                         PushScaleformMovieFunctionParameterInt(it.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(it.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(it.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(it.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     case UIMenuCheckboxItem:
@@ -233,8 +233,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieMethodParameterBool(check.Checked);
                         PushScaleformMovieFunctionParameterInt(check.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(check.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(check.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(check.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     case UIMenuSliderItem:
@@ -244,8 +244,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(prItem.Value);
                         PushScaleformMovieFunctionParameterInt(prItem.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(prItem.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(prItem.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(prItem.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(prItem.SliderColor.ArgbValue);
                         PushScaleformMovieFunctionParameterBool(prItem._heritage);
                         EndScaleformMovieMethod();
@@ -257,8 +257,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(slItem.Value);
                         PushScaleformMovieFunctionParameterInt(slItem.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(slItem.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(slItem.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(slItem.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(slItem.SliderColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
@@ -267,15 +267,15 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterBool(separatorItem.Jumpable);
                         PushScaleformMovieFunctionParameterInt(item.MainColor.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(item.HighlightColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     default:
                         PushScaleformMovieFunctionParameterInt(item.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(item.HighlightColor.ArgbValue/**/);
-                        //PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
-                        //PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_White.ArgbValue);
+                        PushScaleformMovieFunctionParameterInt(SColor.HUD_Black.ArgbValue);
                         EndScaleformMovieMethod();
                         pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL_RIGHT", scaleformIndex, item._formatRightLabel);
                         if (item.RightBadge != BadgeIcon.NONE)

--- a/ScaleformUI_Csharp/Menus/Pause Menus/Elements/Columns/SettingsListColumn.cs
+++ b/ScaleformUI_Csharp/Menus/Pause Menus/Elements/Columns/SettingsListColumn.cs
@@ -125,8 +125,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(it.Index);
                         PushScaleformMovieFunctionParameterInt(it.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(it.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(it.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(it.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(it.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(it.HighlightedTextColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     case UIMenuCheckboxItem:
@@ -135,8 +135,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieMethodParameterBool(check.Checked);
                         PushScaleformMovieFunctionParameterInt(check.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(check.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(check.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(check.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(check.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(check.HighlightedTextColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     case UIMenuSliderItem:
@@ -146,8 +146,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(prItem.Value);
                         PushScaleformMovieFunctionParameterInt(prItem.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(prItem.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(prItem.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(prItem.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(prItem.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(prItem.HighlightedTextColor.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(prItem.SliderColor.ArgbValue);
                         PushScaleformMovieFunctionParameterBool(prItem._heritage);
                         EndScaleformMovieMethod();
@@ -159,8 +159,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(slItem.Value);
                         PushScaleformMovieFunctionParameterInt(slItem.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(slItem.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(slItem.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(slItem.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(slItem.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(slItem.HighlightedTextColor.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(slItem.SliderColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
@@ -169,15 +169,15 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterBool(separatorItem.Jumpable);
                         PushScaleformMovieFunctionParameterInt(item.MainColor.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(item.HighlightColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     default:
                         PushScaleformMovieFunctionParameterInt(item.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(item.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
                         EndScaleformMovieMethod();
                         lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL_RIGHT", scaleformIndex, item._formatRightLabel);
                         if (item.RightBadge != BadgeIcon.NONE)
@@ -223,8 +223,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(it.Index);
                         PushScaleformMovieFunctionParameterInt(it.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(it.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(it.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(it.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(it.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(it.HighlightedTextColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     case UIMenuCheckboxItem:
@@ -233,8 +233,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieMethodParameterBool(check.Checked);
                         PushScaleformMovieFunctionParameterInt(check.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(check.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(check.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(check.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(check.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(check.HighlightedTextColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     case UIMenuSliderItem:
@@ -244,8 +244,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(prItem.Value);
                         PushScaleformMovieFunctionParameterInt(prItem.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(prItem.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(prItem.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(prItem.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(prItem.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(prItem.HighlightedTextColor.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(prItem.SliderColor.ArgbValue);
                         PushScaleformMovieFunctionParameterBool(prItem._heritage);
                         EndScaleformMovieMethod();
@@ -257,8 +257,8 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterInt(slItem.Value);
                         PushScaleformMovieFunctionParameterInt(slItem.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(slItem.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(slItem.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(slItem.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(slItem.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(slItem.HighlightedTextColor.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(slItem.SliderColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
@@ -267,15 +267,15 @@ namespace ScaleformUI.PauseMenus.Elements.Columns
                         PushScaleformMovieFunctionParameterBool(separatorItem.Jumpable);
                         PushScaleformMovieFunctionParameterInt(item.MainColor.ArgbValue);
                         PushScaleformMovieFunctionParameterInt(item.HighlightColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
                         EndScaleformMovieMethod();
                         break;
                     default:
                         PushScaleformMovieFunctionParameterInt(item.MainColor.ArgbValue/**/);
                         PushScaleformMovieFunctionParameterInt(item.HighlightColor.ArgbValue/**/);
-                        PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
-                        PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(item.TextColor.ArgbValue);
+                        //PushScaleformMovieFunctionParameterInt(item.HighlightedTextColor.ArgbValue);
                         EndScaleformMovieMethod();
                         pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL_RIGHT", scaleformIndex, item._formatRightLabel);
                         if (item.RightBadge != BadgeIcon.NONE)

--- a/ScaleformUI_Csharp/Menus/RadialMenu/RadialMenu.cs
+++ b/ScaleformUI_Csharp/Menus/RadialMenu/RadialMenu.cs
@@ -132,7 +132,7 @@ namespace ScaleformUI.Radial
             Main.radialMenu.CallFunction("LOAD_MENU", currentSelection, Segments[0].CurrentSelection, Segments[1].CurrentSelection, Segments[2].CurrentSelection, Segments[3].CurrentSelection, Segments[4].CurrentSelection, Segments[5].CurrentSelection, Segments[6].CurrentSelection, Segments[7].CurrentSelection);
         }
 
-        internal override async void ProcessControl(Keys key = Keys.None)
+        internal override async void ProcessControl()
         {
             Controls.Toggle(false);
             // block camera movements

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuCheckboxItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuCheckboxItem.cs
@@ -75,10 +75,8 @@ namespace ScaleformUI.Menu
             set
             {
                 _checked = value;
-                //if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                //{
-                //    Main.scaleformUI.CallFunction("SET_INPUT_EVENT", 16, Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), value);
-                //}
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
             }
         }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuCheckboxItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuCheckboxItem.cs
@@ -58,7 +58,7 @@ namespace ScaleformUI.Menu
         /// <param name="description">Description for this item.</param>
         /// <param name="mainColor">Main item color.</param>
         /// <param name="highlightColor">Highlight item color.</param>
-        public UIMenuCheckboxItem(string text, UIMenuCheckboxStyle style, bool check, string description, SColor mainColor, SColor highlightColor) : base(text, description, mainColor, highlightColor, SColor.HUD_White, SColor.HUD_Black)
+        public UIMenuCheckboxItem(string text, UIMenuCheckboxStyle style, bool check, string description, SColor mainColor, SColor highlightColor) : base(text, description, mainColor, highlightColor)
         {
             Style = style;
             _checked = check;
@@ -75,10 +75,10 @@ namespace ScaleformUI.Menu
             set
             {
                 _checked = value;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("SET_INPUT_EVENT", 16, Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), value);
-                }
+                //if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
+                //{
+                //    Main.scaleformUI.CallFunction("SET_INPUT_EVENT", 16, Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), value);
+                //}
             }
         }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuDynamicListItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuDynamicListItem.cs
@@ -28,20 +28,18 @@ namespace ScaleformUI.Menu
                 if (!Enabled)
                     str = str.ReplaceRstarColorsWith("~c~");
                 if (Parent is not null && Parent.Visible)
-                {
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                    {
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                    }
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    {
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                    }
                 }
-                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //    {
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                //    }
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //    {
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                //    }
-                //}
             }
         }
 
@@ -54,21 +52,17 @@ namespace ScaleformUI.Menu
                 var str = Selected ? (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~l~", "~s~");
                 if (!Enabled)
                     str = str.ReplaceRstarColorsWith("~c~");
-                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                //{
-                //    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), str, 0);
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //    {
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                //    }
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //    {
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                //    }
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                    {
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                    }
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    {
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                    }
+                }
             }
         }
 
@@ -81,21 +75,17 @@ namespace ScaleformUI.Menu
                 var str = Selected ? (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~l~", "~s~");
                 if (!Enabled)
                     str = str.ReplaceRstarColorsWith("~c~");
-                //if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                //{
-                //    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), str, 0);
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //    {
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                //    }
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //    {
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                //    }
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                    {
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                    }
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    {
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                    }
+                }
             }
         }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuDynamicListItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuDynamicListItem.cs
@@ -24,13 +24,13 @@ namespace ScaleformUI.Menu
             set
             {
                 currentListItem = value;
-                var str = Selected ? (value.StartsWith("~") ? value : "~s~" + value).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (value.StartsWith("~") ? value : "~s~" + value).ToString().Replace("~l~", "~s~");
-                if (!Enabled)
-                    str = str.ReplaceRstarColorsWith("~c~");
                 if (Parent is not null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
                 if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
                 {
+                    var str = Selected ? (value.StartsWith("~") ? value : "~s~" + value).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (value.StartsWith("~") ? value : "~s~" + value).ToString().Replace("~l~", "~s~");
+                    if (!Enabled)
+                        str = str.ReplaceRstarColorsWith("~c~");
                     if (ParentColumn.Parent is MainView lobby)
                     {
                         lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
@@ -43,6 +43,7 @@ namespace ScaleformUI.Menu
             }
         }
 
+
         public override bool Enabled
         {
             get => base.Enabled;
@@ -52,6 +53,8 @@ namespace ScaleformUI.Menu
                 var str = Selected ? (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~l~", "~s~");
                 if (!Enabled)
                     str = str.ReplaceRstarColorsWith("~c~");
+                if (Parent is not null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
                 if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
                 {
                     if (ParentColumn.Parent is MainView lobby)
@@ -75,6 +78,8 @@ namespace ScaleformUI.Menu
                 var str = Selected ? (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~l~", "~s~");
                 if (!Enabled)
                     str = str.ReplaceRstarColorsWith("~c~");
+                if (Parent is not null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
                 if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
                 {
                     if (ParentColumn.Parent is MainView lobby)
@@ -99,7 +104,6 @@ namespace ScaleformUI.Menu
         public UIMenuDynamicListItem(string text, string startingItem, DynamicListItemChangeCallback changeCallback) : this(text, null, startingItem, changeCallback)
         {
         }
-
 
         /// <summary>
         /// List item with items generated at runtime

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuDynamicListItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuDynamicListItem.cs
@@ -27,21 +27,21 @@ namespace ScaleformUI.Menu
                 var str = Selected ? (value.StartsWith("~") ? value : "~s~" + value).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (value.StartsWith("~") ? value : "~s~" + value).ToString().Replace("~l~", "~s~");
                 if (!Enabled)
                     str = str.ReplaceRstarColorsWith("~c~");
-                if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
+                if (Parent is not null && Parent.Visible)
                 {
-                    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), str, 0);
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
                 }
-                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                    }
-                }
+                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //    {
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                //    }
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //    {
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                //    }
+                //}
             }
         }
 
@@ -54,21 +54,21 @@ namespace ScaleformUI.Menu
                 var str = Selected ? (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~l~", "~s~");
                 if (!Enabled)
                     str = str.ReplaceRstarColorsWith("~c~");
-                if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), str, 0);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                    }
-                }
+                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
+                //{
+                //    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), str, 0);
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //    {
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                //    }
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //    {
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                //    }
+                //}
             }
         }
 
@@ -81,21 +81,21 @@ namespace ScaleformUI.Menu
                 var str = Selected ? (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (CurrentListItem.StartsWith("~") ? CurrentListItem : "~s~" + CurrentListItem).ToString().Replace("~l~", "~s~");
                 if (!Enabled)
                     str = str.ReplaceRstarColorsWith("~c~");
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), str, 0);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
-                    }
-                }
+                //if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
+                //{
+                //    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), str, 0);
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //    {
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                //    }
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //    {
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), str, 0);
+                //    }
+                //}
             }
         }
 
@@ -110,6 +110,7 @@ namespace ScaleformUI.Menu
         {
         }
 
+
         /// <summary>
         /// List item with items generated at runtime
         /// </summary>
@@ -120,6 +121,12 @@ namespace ScaleformUI.Menu
             _itemId = 1;
             currentListItem = startingItem;
             Callback = changeCallback;
+        }
+
+        internal UIMenuDynamicListItem(string text, string description, string startingItem) : base(text, description)
+        {
+            _itemId = 1;
+            currentListItem = startingItem;
         }
 
         public override void SetRightBadge(BadgeIcon badge)

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
@@ -409,7 +409,10 @@ namespace ScaleformUI.Menu
             {
                 description = value;
                 if (Parent != null && Parent.Visible)
+                {
+                    API.AddTextEntry("UIMenu_Current_Description", value);
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                }
                 if (ParentColumn != null && ParentColumn.Parent.Visible)
                 {
                     API.AddTextEntry("PAUSEMENU_Current_Description", value);

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
@@ -220,11 +220,10 @@ namespace ScaleformUI.Menu
         private SColor textColor = SColor.HUD_White;
         private SColor highlightedTextColor = SColor.HUD_Black;
         private string description;
-        private uint descriptionHash;
         internal ItemFont labelFont = ScaleformFonts.CHALET_LONDON_NINETEENSIXTY;
         internal ItemFont rightLabelFont = ScaleformFonts.CHALET_LONDON_NINETEENSIXTY;
-        internal KeyValuePair<string, string> customLeftBadge;
-        internal KeyValuePair<string, string> customRightBadge;
+        internal KeyValuePair<string, string> customLeftBadge = new KeyValuePair<string, string>("", "");
+        internal KeyValuePair<string, string> customRightBadge = new KeyValuePair<string, string>("", "");
 
         /// <summary>
         /// The item color when not highlighted
@@ -235,10 +234,8 @@ namespace ScaleformUI.Menu
             set
             {
                 mainColor = value;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), value, highlightColor, textColor, highlightedTextColor);
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
             }
         }
         /// <summary>
@@ -250,43 +247,13 @@ namespace ScaleformUI.Menu
             set
             {
                 highlightColor = value;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), mainColor, value, textColor, highlightedTextColor);
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
             }
         }
         /// <summary>
         /// The item text color when not highlighted
         /// </summary>
-
-        public SColor TextColor
-        {
-            get => textColor;
-            set
-            {
-                textColor = value;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), mainColor, highlightColor, value, highlightedTextColor);
-                }
-            }
-        }
-        /// <summary>
-        /// The item text color when highlighted
-        /// </summary>
-        public SColor HighlightedTextColor
-        {
-            get => highlightedTextColor;
-            set
-            {
-                highlightedTextColor = value;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), mainColor, highlightColor, textColor, value);
-                }
-            }
-        }
 
         public ItemFont LabelFont
         {
@@ -294,17 +261,18 @@ namespace ScaleformUI.Menu
             set
             {
                 labelFont = value;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("SET_ITEM_LABEL_FONT", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible)
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //{
+                //    Main.scaleformUI.CallFunction("SET_ITEM_LABEL_FONT", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), labelFont.FontName, labelFont.FontID);
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent.Visible)
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
+                //}
             }
         }
 
@@ -314,17 +282,18 @@ namespace ScaleformUI.Menu
             set
             {
                 rightLabelFont = value;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("SET_ITEM_RIGHT_LABEL_FONT", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), rightLabelFont.FontName, rightLabelFont.FontID);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible)
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_RIGHT_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_RIGHT_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //{
+                //    Main.scaleformUI.CallFunction("SET_ITEM_RIGHT_LABEL_FONT", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), rightLabelFont.FontName, rightLabelFont.FontID);
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent.Visible)
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_RIGHT_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_RIGHT_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
+                //}
             }
         }
 
@@ -358,15 +327,7 @@ namespace ScaleformUI.Menu
         /// </summary>
         /// <param name="text">Button label.</param>
         /// <param name="description">Description.</param>
-        public UIMenuItem(string text, string description) : this(text, description, SColor.HUD_Panel_light, SColor.HUD_White, SColor.HUD_White, SColor.HUD_Black) { }
-
-        /// <summary>
-        /// Basic menu button with description.
-        /// </summary>
-        /// <param name="text">Button label.</param>
-        /// <param name="descriptionHash">Description label hash.</param>
-
-        public UIMenuItem(string text, string description, SColor mainColor, SColor highlightColor) : this(text, description, mainColor, highlightColor, SColor.HUD_White, SColor.HUD_Black) { }
+        public UIMenuItem(string text, string description) : this(text, description, SColor.HUD_Panel_light, SColor.HUD_White) { }
 
         /// <summary>
         /// Basic menu item with description and colors.
@@ -375,15 +336,11 @@ namespace ScaleformUI.Menu
         /// <param name="description">Item's description</param>
         /// <param name="color">Main Color</param>
         /// <param name="highlightColor">Highlighted Color</param>
-        /// <param name="textColor">Text's main color</param>
-        /// <param name="highlightedTextColor">Highlighted text color</param>
-        public UIMenuItem(string text, string description, SColor color, SColor highlightColor, SColor textColor, SColor highlightedTextColor)
+        public UIMenuItem(string text, string description, SColor color, SColor highlightColor)
         {
             _enabled = true;
             MainColor = color;
             HighlightColor = highlightColor;
-            TextColor = textColor;
-            HighlightedTextColor = highlightedTextColor;
             Label = text;
             Description = description;
         }
@@ -398,17 +355,18 @@ namespace ScaleformUI.Menu
             set
             {
                 blinkDescription = value;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("SET_BLINK_DESC", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), blinkDescription);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible)
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_BLINK_DESC", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), blinkDescription);
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_BLINK_DESC", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), blinkDescription);
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //{
+                //    Main.scaleformUI.CallFunction("SET_BLINK_DESC", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), blinkDescription);
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent.Visible)
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_BLINK_DESC", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), blinkDescription);
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_BLINK_DESC", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), blinkDescription);
+                //}
             }
         }
 
@@ -434,17 +392,18 @@ namespace ScaleformUI.Menu
                     if (!string.IsNullOrWhiteSpace(_formatRightLabel))
                         _formatRightLabel = _formatRightLabel.Replace("~l~", "~s~");
                 }
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("SET_ITEM_LABELS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                }
-                if (ParentColumn != null && ParentColumn.Parent != null && ParentColumn.Parent.Visible)
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //{
+                //    Main.scaleformUI.CallFunction("SET_ITEM_LABELS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent != null && ParentColumn.Parent.Visible)
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                //}
             }
         }
 
@@ -463,60 +422,17 @@ namespace ScaleformUI.Menu
             set
             {
                 description = value;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    API.AddTextEntry("UIMenu_Current_Description", value);
-                    Parent.UpdateDescription();
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible)
-                {
-                    API.AddTextEntry("PAUSEMENU_Current_Description", value);
-                    ParentColumn.UpdateDescription();
-                }
-            }
-        }
-        /// <summary>
-        /// Sets the item's description by a label's hash (used by (uint)GetHashKey(label))
-        /// </summary>
-        [Obsolete("Deprecated because unused.")]
-        public virtual uint DescriptionHash
-        {
-            get => descriptionHash;
-            set
-            {
-                descriptionHash = value;
-                if (!string.IsNullOrWhiteSpace(description))
-                    description = string.Empty;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    API.BeginScaleformMovieMethod(Main.scaleformUI.Handle, "UPDATE_ITEM_DESCRIPTION");
-                    API.ScaleformMovieMethodAddParamInt(Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)));
-                    API.BeginTextCommandScaleformString("STRTNM1");
-                    API.AddTextComponentSubstringTextLabelHashKey(descriptionHash);
-                    API.EndTextCommandScaleformString_2();
-                    API.EndScaleformMovieMethod();
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible)
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        API.BeginScaleformMovieMethod(lobby._pause._lobby.Handle, "UPDATE_SETTINGS_ITEM_DESCRIPTION");
-                        API.ScaleformMovieMethodAddParamInt(ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)));
-                        API.BeginTextCommandScaleformString("STRTNM1");
-                        API.AddTextComponentSubstringTextLabelHashKey(descriptionHash);
-                        API.EndTextCommandScaleformString_2();
-                        API.EndScaleformMovieMethod();
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        API.BeginScaleformMovieMethod(pause._pause._pause.Handle, ""); // da aggiungere
-                        API.ScaleformMovieMethodAddParamInt(ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)));
-                        API.BeginTextCommandScaleformString("STRTNM1");
-                        API.AddTextComponentSubstringTextLabelHashKey(descriptionHash);
-                        API.EndTextCommandScaleformString_2();
-                        API.EndScaleformMovieMethod();
-                    }
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //{
+                //    API.AddTextEntry("UIMenu_Current_Description", value);
+                //    Parent.UpdateDescription();
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent.Visible)
+                //{
+                //    API.AddTextEntry("PAUSEMENU_Current_Description", value);
+                //    ParentColumn.UpdateDescription();
+                //}
             }
         }
 
@@ -534,24 +450,25 @@ namespace ScaleformUI.Menu
                     _formatLeftLabel = _formatLeftLabel.ReplaceRstarColorsWith("~c~");
                 else
                     Label = _label;
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("SET_ITEM_LABELS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                    Main.scaleformUI.CallFunction("ENABLE_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _enabled);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                        lobby._pause._lobby.CallFunction("ENABLE_SETTINGS_ITEM", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _enabled);
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                        pause._pause._pause.CallFunction("ENABLE_PLAYERS_TAB_SETTINGS_ITEM", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _enabled);
-                    }
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //{
+                //    Main.scaleformUI.CallFunction("SET_ITEM_LABELS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                //    Main.scaleformUI.CallFunction("ENABLE_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _enabled);
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //    {
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                //        lobby._pause._lobby.CallFunction("ENABLE_SETTINGS_ITEM", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _enabled);
+                //    }
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //    {
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                //        pause._pause._pause.CallFunction("ENABLE_PLAYERS_TAB_SETTINGS_ITEM", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _enabled);
+                //    }
+                //}
             }
         }
 
@@ -573,17 +490,18 @@ namespace ScaleformUI.Menu
                 _label = value;
                 _formatLeftLabel = value.StartsWith("~") ? value : "~s~" + value;
                 _formatLeftLabel = !_enabled ? _formatLeftLabel.ReplaceRstarColorsWith("~c~") : _selected ? _formatLeftLabel.Replace("~w~", "~l~").Replace("~s~", "~l~") : _formatLeftLabel.Replace("~l~", "~s~");
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("SET_LEFT_LABEL", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatLeftLabel);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible)
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel);
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel);
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //{
+                //    Main.scaleformUI.CallFunction("SET_LEFT_LABEL", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatLeftLabel);
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent.Visible)
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel);
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel);
+                //}
             }
         }
 
@@ -595,17 +513,18 @@ namespace ScaleformUI.Menu
         public virtual void SetLeftBadge(BadgeIcon badge)
         {
             LeftBadge = badge;
-            if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-            {
-                Main.scaleformUI.CallFunction("SET_LEFT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), (int)badge);
-            }
-            if (ParentColumn != null && ParentColumn.Parent.Visible)
-            {
-                if (ParentColumn.Parent is MainView lobby)
-                    lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
-                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
-            }
+            if (Parent != null && Parent.Visible)
+                Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+            //{
+            //    Main.scaleformUI.CallFunction("SET_LEFT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), (int)badge);
+            //}
+            //if (ParentColumn != null && ParentColumn.Parent.Visible)
+            //{
+            //    if (ParentColumn.Parent is MainView lobby)
+            //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
+            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+            //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
+            //}
         }
 
         /// <summary>
@@ -615,17 +534,18 @@ namespace ScaleformUI.Menu
         public virtual void SetRightBadge(BadgeIcon badge)
         {
             RightBadge = badge;
-            if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-            {
-                Main.scaleformUI.CallFunction("SET_RIGHT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), (int)badge);
-            }
-            if (ParentColumn != null && ParentColumn.Parent.Visible)
-            {
-                if (ParentColumn.Parent is MainView lobby)
-                    lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
-                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
-            }
+            if (Parent != null && Parent.Visible)
+                Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+            //{
+            //    Main.scaleformUI.CallFunction("SET_RIGHT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), (int)badge);
+            //}
+            //if (ParentColumn != null && ParentColumn.Parent.Visible)
+            //{
+            //    if (ParentColumn.Parent is MainView lobby)
+            //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
+            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+            //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
+            //}
         }
 
         /// <summary>
@@ -638,17 +558,18 @@ namespace ScaleformUI.Menu
         {
             RightBadge = BadgeIcon.CUSTOM;
             customRightBadge = new KeyValuePair<string, string>(txd, txn);
-            if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-            {
-                Main.scaleformUI.CallFunction("SET_CUSTOM_RIGHT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), txd,txn);
-            }
-            if (ParentColumn != null && ParentColumn.Parent.Visible)
-            {
-                if (ParentColumn.Parent is MainView lobby)
-                    lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_CUSTOM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
-                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_CUSTOM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
-            }
+            if (Parent != null && Parent.Visible)
+                Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+            //{
+            //    Main.scaleformUI.CallFunction("SET_CUSTOM_RIGHT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), txd,txn);
+            //}
+            //if (ParentColumn != null && ParentColumn.Parent.Visible)
+            //{
+            //    if (ParentColumn.Parent is MainView lobby)
+            //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_CUSTOM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
+            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+            //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_CUSTOM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
+            //}
         }
 
         /// <summary>
@@ -661,17 +582,18 @@ namespace ScaleformUI.Menu
         {
             LeftBadge = BadgeIcon.CUSTOM;
             customLeftBadge = new KeyValuePair<string, string>(txd, txn);
-            if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-            {
-                Main.scaleformUI.CallFunction("SET_CUSTOM_LEFT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), txd, txn);
-            }
-            if (ParentColumn != null && ParentColumn.Parent.Visible)
-            {
-                if (ParentColumn.Parent is MainView lobby)
-                    lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_CUSTOM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
-                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_CUSTOM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
-            }
+            if (Parent != null && Parent.Visible)
+                Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+            //{
+            //    Main.scaleformUI.CallFunction("SET_CUSTOM_LEFT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), txd, txn);
+            //}
+            //if (ParentColumn != null && ParentColumn.Parent.Visible)
+            //{
+            //    if (ParentColumn.Parent is MainView lobby)
+            //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_CUSTOM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
+            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+            //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_CUSTOM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
+            //}
         }
 
 
@@ -695,17 +617,18 @@ namespace ScaleformUI.Menu
                 _rightLabel = value;
                 _formatRightLabel = value.StartsWith("~") ? value : "~s~" + value;
                 _formatRightLabel = !_enabled ? _formatRightLabel.ReplaceRstarColorsWith("~c~") : _selected ? _formatRightLabel .Replace("~w~", "~l~").Replace("~s~", "~l~") : _formatRightLabel .Replace("~l~", "~s~");
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("SET_RIGHT_LABEL", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatRightLabel);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible)
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL_RIGHT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatRightLabel);
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL_RIGHT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatRightLabel);
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //{
+                //    Main.scaleformUI.CallFunction("SET_RIGHT_LABEL", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatRightLabel);
+                //}
+                //if (ParentColumn != null && ParentColumn.Parent.Visible)
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL_RIGHT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatRightLabel);
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL_RIGHT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatRightLabel);
+                //}
             }
         }
 
@@ -731,10 +654,11 @@ namespace ScaleformUI.Menu
         public virtual void RemovePanelAt(int Index)
         {
             Panels.RemoveAt(Index);
-            if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-            {
-                Main.scaleformUI.CallFunction("REMOVE_PANEL", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), Index);
-            }
+            if (Parent != null && Parent.Visible)
+                Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+            //{
+            //    Main.scaleformUI.CallFunction("REMOVE_PANEL", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), Index);
+            //}
         }
 
         /// <summary>
@@ -745,18 +669,19 @@ namespace ScaleformUI.Menu
         {
             panel.SetParentItem(this);
             SidePanel = panel;
-            if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-            {
-                switch (panel)
-                {
-                    case UIMissionDetailsPanel:
-                        UIMissionDetailsPanel mis = (UIMissionDetailsPanel)panel;
-                        Main.scaleformUI.CallFunction("ADD_SIDE_PANEL_TO_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), 0, (int)mis.PanelSide, (int)mis._titleType, mis.Title, mis.TitleColor, mis.TextureDict, mis.TextureName);
-                        foreach (UIFreemodeDetailsItem _it in mis.Items)
-                            Main.scaleformUI.CallFunction("ADD_MISSION_DETAILS_DESC_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _it.Type, _it.TextLeft, _it.TextRight, (int)_it.Icon, _it.IconColor, _it.Tick);
-                        break;
-                }
-            }
+            if (Parent != null && Parent.Visible)
+                Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+            //{
+            //    switch (panel)
+            //    {
+            //        case UIMissionDetailsPanel:
+            //            UIMissionDetailsPanel mis = (UIMissionDetailsPanel)panel;
+            //            Main.scaleformUI.CallFunction("ADD_SIDE_PANEL_TO_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), 0, (int)mis.PanelSide, (int)mis._titleType, mis.Title, mis.TitleColor, mis.TextureDict, mis.TextureName);
+            //            foreach (UIFreemodeDetailsItem _it in mis.Items)
+            //                Main.scaleformUI.CallFunction("ADD_MISSION_DETAILS_DESC_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _it.Type, _it.TextLeft, _it.TextRight, (int)_it.Icon, _it.IconColor, _it.Tick);
+            //            break;
+            //    }
+            //}
         }
 
         /// <summary>
@@ -765,18 +690,17 @@ namespace ScaleformUI.Menu
         public virtual void RemoveSidePanel()
         {
             SidePanel = null;
-            if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-            {
-                Main.scaleformUI.CallFunction("REMOVE_SIDE_PANEL_TO_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)));
-            }
+            if (Parent != null && Parent.Visible)
+                Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+            //{
+            //    Main.scaleformUI.CallFunction("REMOVE_SIDE_PANEL_TO_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)));
+            //}
         }
 
         /// <summary>
         /// Returns the current right badge.
         /// </summary>
         public virtual BadgeIcon RightBadge { get; private set; }
-
-
 
         /// <summary>
         /// Returns the menu this item is in.

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuItem.cs
@@ -217,8 +217,6 @@ namespace ScaleformUI.Menu
         private bool blinkDescription;
         private SColor mainColor;
         private SColor highlightColor;
-        private SColor textColor = SColor.HUD_White;
-        private SColor highlightedTextColor = SColor.HUD_Black;
         private string description;
         internal ItemFont labelFont = ScaleformFonts.CHALET_LONDON_NINETEENSIXTY;
         internal ItemFont rightLabelFont = ScaleformFonts.CHALET_LONDON_NINETEENSIXTY;
@@ -263,16 +261,13 @@ namespace ScaleformUI.Menu
                 labelFont = value;
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //{
-                //    Main.scaleformUI.CallFunction("SET_ITEM_LABEL_FONT", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent.Visible)
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible)
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
+                }
             }
         }
 
@@ -284,16 +279,13 @@ namespace ScaleformUI.Menu
                 rightLabelFont = value;
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //{
-                //    Main.scaleformUI.CallFunction("SET_ITEM_RIGHT_LABEL_FONT", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), rightLabelFont.FontName, rightLabelFont.FontID);
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent.Visible)
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_RIGHT_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_RIGHT_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible)
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_RIGHT_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_RIGHT_LABEL_FONT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), labelFont.FontName, labelFont.FontID);
+                }
             }
         }
 
@@ -357,16 +349,13 @@ namespace ScaleformUI.Menu
                 blinkDescription = value;
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //{
-                //    Main.scaleformUI.CallFunction("SET_BLINK_DESC", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), blinkDescription);
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent.Visible)
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_BLINK_DESC", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), blinkDescription);
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_BLINK_DESC", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), blinkDescription);
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible)
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_BLINK_DESC", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), blinkDescription);
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_BLINK_DESC", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), blinkDescription);
+                }
             }
         }
 
@@ -394,16 +383,13 @@ namespace ScaleformUI.Menu
                 }
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //{
-                //    Main.scaleformUI.CallFunction("SET_ITEM_LABELS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent != null && ParentColumn.Parent.Visible)
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                //}
+                if (ParentColumn != null && ParentColumn.Parent != null && ParentColumn.Parent.Visible)
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                }
             }
         }
 
@@ -424,15 +410,11 @@ namespace ScaleformUI.Menu
                 description = value;
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //{
-                //    API.AddTextEntry("UIMenu_Current_Description", value);
-                //    Parent.UpdateDescription();
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent.Visible)
-                //{
-                //    API.AddTextEntry("PAUSEMENU_Current_Description", value);
-                //    ParentColumn.UpdateDescription();
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible)
+                {
+                    API.AddTextEntry("PAUSEMENU_Current_Description", value);
+                    ParentColumn.UpdateDescription();
+                }
             }
         }
 
@@ -452,23 +434,19 @@ namespace ScaleformUI.Menu
                     Label = _label;
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //{
-                //    Main.scaleformUI.CallFunction("SET_ITEM_LABELS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                //    Main.scaleformUI.CallFunction("ENABLE_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _enabled);
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //    {
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                //        lobby._pause._lobby.CallFunction("ENABLE_SETTINGS_ITEM", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _enabled);
-                //    }
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //    {
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
-                //        pause._pause._pause.CallFunction("ENABLE_PLAYERS_TAB_SETTINGS_ITEM", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _enabled);
-                //    }
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                    {
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                        lobby._pause._lobby.CallFunction("ENABLE_SETTINGS_ITEM", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _enabled);
+                    }
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    {
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABELS", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel, _formatRightLabel);
+                        pause._pause._pause.CallFunction("ENABLE_PLAYERS_TAB_SETTINGS_ITEM", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _enabled);
+                    }
+                }
             }
         }
 
@@ -492,16 +470,13 @@ namespace ScaleformUI.Menu
                 _formatLeftLabel = !_enabled ? _formatLeftLabel.ReplaceRstarColorsWith("~c~") : _selected ? _formatLeftLabel.Replace("~w~", "~l~").Replace("~s~", "~l~") : _formatLeftLabel.Replace("~l~", "~s~");
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //{
-                //    Main.scaleformUI.CallFunction("SET_LEFT_LABEL", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatLeftLabel);
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent.Visible)
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel);
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel);
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible)
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel);
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatLeftLabel);
+                }
             }
         }
 
@@ -515,16 +490,13 @@ namespace ScaleformUI.Menu
             LeftBadge = badge;
             if (Parent != null && Parent.Visible)
                 Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-            //{
-            //    Main.scaleformUI.CallFunction("SET_LEFT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), (int)badge);
-            //}
-            //if (ParentColumn != null && ParentColumn.Parent.Visible)
-            //{
-            //    if (ParentColumn.Parent is MainView lobby)
-            //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
-            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-            //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
-            //}
+            if (ParentColumn != null && ParentColumn.Parent.Visible)
+            {
+                if (ParentColumn.Parent is MainView lobby)
+                    lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
+                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
+            }
         }
 
         /// <summary>
@@ -536,16 +508,13 @@ namespace ScaleformUI.Menu
             RightBadge = badge;
             if (Parent != null && Parent.Visible)
                 Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-            //{
-            //    Main.scaleformUI.CallFunction("SET_RIGHT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), (int)badge);
-            //}
-            //if (ParentColumn != null && ParentColumn.Parent.Visible)
-            //{
-            //    if (ParentColumn.Parent is MainView lobby)
-            //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
-            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-            //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
-            //}
+            if (ParentColumn != null && ParentColumn.Parent.Visible)
+            {
+                if (ParentColumn.Parent is MainView lobby)
+                    lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
+                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), (int)badge);
+            }
         }
 
         /// <summary>
@@ -560,16 +529,13 @@ namespace ScaleformUI.Menu
             customRightBadge = new KeyValuePair<string, string>(txd, txn);
             if (Parent != null && Parent.Visible)
                 Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-            //{
-            //    Main.scaleformUI.CallFunction("SET_CUSTOM_RIGHT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), txd,txn);
-            //}
-            //if (ParentColumn != null && ParentColumn.Parent.Visible)
-            //{
-            //    if (ParentColumn.Parent is MainView lobby)
-            //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_CUSTOM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
-            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-            //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_CUSTOM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
-            //}
+            if (ParentColumn != null && ParentColumn.Parent.Visible)
+            {
+                if (ParentColumn.Parent is MainView lobby)
+                    lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_CUSTOM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
+                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_CUSTOM_RIGHT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
+            }
         }
 
         /// <summary>
@@ -584,16 +550,13 @@ namespace ScaleformUI.Menu
             customLeftBadge = new KeyValuePair<string, string>(txd, txn);
             if (Parent != null && Parent.Visible)
                 Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-            //{
-            //    Main.scaleformUI.CallFunction("SET_CUSTOM_LEFT_BADGE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), txd, txn);
-            //}
-            //if (ParentColumn != null && ParentColumn.Parent.Visible)
-            //{
-            //    if (ParentColumn.Parent is MainView lobby)
-            //        lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_CUSTOM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
-            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-            //        pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_CUSTOM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
-            //}
+            if (ParentColumn != null && ParentColumn.Parent.Visible)
+            {
+                if (ParentColumn.Parent is MainView lobby)
+                    lobby._pause._lobby.CallFunction("SET_SETTINGS_ITEM_CUSTOM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
+                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    pause._pause._pause.CallFunction("SET_PLAYERS_TAB_SETTINGS_ITEM_CUSTOM_LEFT_BADGE", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), txd, txn);
+            }
         }
 
 
@@ -619,16 +582,13 @@ namespace ScaleformUI.Menu
                 _formatRightLabel = !_enabled ? _formatRightLabel.ReplaceRstarColorsWith("~c~") : _selected ? _formatRightLabel .Replace("~w~", "~l~").Replace("~s~", "~l~") : _formatRightLabel .Replace("~l~", "~s~");
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //{
-                //    Main.scaleformUI.CallFunction("SET_RIGHT_LABEL", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _formatRightLabel);
-                //}
-                //if (ParentColumn != null && ParentColumn.Parent.Visible)
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL_RIGHT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatRightLabel);
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL_RIGHT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatRightLabel);
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible)
+                {
+                    if (ParentColumn.Parent is MainView lobby)
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_ITEM_LABEL_RIGHT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatRightLabel);
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_ITEM_LABEL_RIGHT", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), _formatRightLabel);
+                }
             }
         }
 
@@ -656,9 +616,6 @@ namespace ScaleformUI.Menu
             Panels.RemoveAt(Index);
             if (Parent != null && Parent.Visible)
                 Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-            //{
-            //    Main.scaleformUI.CallFunction("REMOVE_PANEL", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), Index);
-            //}
         }
 
         /// <summary>
@@ -671,17 +628,6 @@ namespace ScaleformUI.Menu
             SidePanel = panel;
             if (Parent != null && Parent.Visible)
                 Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-            //{
-            //    switch (panel)
-            //    {
-            //        case UIMissionDetailsPanel:
-            //            UIMissionDetailsPanel mis = (UIMissionDetailsPanel)panel;
-            //            Main.scaleformUI.CallFunction("ADD_SIDE_PANEL_TO_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), 0, (int)mis.PanelSide, (int)mis._titleType, mis.Title, mis.TitleColor, mis.TextureDict, mis.TextureName);
-            //            foreach (UIFreemodeDetailsItem _it in mis.Items)
-            //                Main.scaleformUI.CallFunction("ADD_MISSION_DETAILS_DESC_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _it.Type, _it.TextLeft, _it.TextRight, (int)_it.Icon, _it.IconColor, _it.Tick);
-            //            break;
-            //    }
-            //}
         }
 
         /// <summary>
@@ -692,9 +638,6 @@ namespace ScaleformUI.Menu
             SidePanel = null;
             if (Parent != null && Parent.Visible)
                 Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-            //{
-            //    Main.scaleformUI.CallFunction("REMOVE_SIDE_PANEL_TO_ITEM", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)));
-            //}
         }
 
         /// <summary>

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuListItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuListItem.cs
@@ -4,6 +4,7 @@ using ScaleformUI.PauseMenu;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace ScaleformUI.Menu
 {
@@ -38,8 +39,10 @@ namespace ScaleformUI.Menu
                     _index = 0;
                 else
                     _index = value;
-                if(Parent != null && Parent.Visible)
+                if (_items.Count > 0)
                     CurrentListItem = Items[_index].ToString();
+                else
+                    CurrentListItem = "";
                 if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
                 {
                     string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
@@ -67,64 +70,12 @@ namespace ScaleformUI.Menu
             set
             {
                 _items = new(value);
-                CurrentListItem = Items[_index].ToString();
+                if (_items.Count > 0)
+                    CurrentListItem = Items[_index].ToString();
+                else
+                    CurrentListItem = "";
             }
         }
-
-        public override bool Enabled
-        {
-            get => base.Enabled;
-            set
-            {
-                base.Enabled = value;
-                if (Parent != null && Parent.Visible)
-                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                {
-                    string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
-                        x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
-                    ));
-                    if (!Enabled)
-                        joinedList = joinedList.ReplaceRstarColorsWith("~c~");
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                }
-            }
-        }
-
-        public override bool Selected
-        {
-            get => base.Selected;
-            internal set
-            {
-                base.Selected = value;
-                if (Parent != null && Parent.Visible)
-                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                {
-                    string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
-                        x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
-                    ));
-                    if (!Enabled)
-                        joinedList = joinedList.ReplaceRstarColorsWith("~c~");
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                }
-            }
-        }
-
 
         /// <summary>
         /// List item, with left/right arrows.
@@ -152,11 +103,18 @@ namespace ScaleformUI.Menu
             return await ((UIMenuListItem)sender).getIndex(direction);
         };
 
-        public UIMenuListItem(string text, List<object> items, int index, string description, SColor mainColor, SColor higlightColor) : base(text, description, "" + items[index])
+        public UIMenuListItem(string text, List<object> items, int index, string description, SColor mainColor, SColor higlightColor) : base(text, description, "")
         {
             _items = new(items);
-            Index = index;
+            if (index > items.Count)
+                Index = 0;
+            else
+                Index = index;
             Callback = _callback;
+            if (items.Count > 0)
+            {
+                CurrentListItem = items[Index].ToString();
+            }
         }
 
         private async Task<string> getIndex(ChangeDirection d)
@@ -164,7 +122,7 @@ namespace ScaleformUI.Menu
             if (d == ChangeDirection.Left)
             {
                 _index--;
-                if(_index < 0)
+                if (_index < 0)
                     _index = Items.Count - 1;
             }
             else
@@ -259,7 +217,7 @@ namespace ScaleformUI.Menu
         [Obsolete("Use CurrentListItem instead.")]
         public string CurrentItem()
         {
-            return _items[Index].ToString();
+            return CurrentListItem;
         }
     }
 }

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuListItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuListItem.cs
@@ -38,7 +38,23 @@ namespace ScaleformUI.Menu
                     _index = 0;
                 else
                     _index = value;
-                CurrentListItem = Items[_index].ToString();
+                if(Parent != null && Parent.Visible)
+                    CurrentListItem = Items[_index].ToString();
+                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                {
+                    string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
+                        x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
+                    ));
+                    if (ParentColumn.Parent is MainView lobby)
+                    {
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                    }
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    {
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                    }
+                }
+
             }
         }
 
@@ -63,17 +79,22 @@ namespace ScaleformUI.Menu
                 base.Enabled = value;
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //    {
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                //    }
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //    {
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                //    }
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                {
+                    string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
+                        x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
+                    ));
+                    if (!Enabled)
+                        joinedList = joinedList.ReplaceRstarColorsWith("~c~");
+                    if (ParentColumn.Parent is MainView lobby)
+                    {
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                    }
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    {
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                    }
+                }
             }
         }
 
@@ -85,17 +106,22 @@ namespace ScaleformUI.Menu
                 base.Selected = value;
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                //{
-                //    if (ParentColumn.Parent is MainView lobby)
-                //    {
-                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                //    }
-                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                //    {
-                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                //    }
-                //}
+                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                {
+                    string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
+                        x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
+                    ));
+                    if (!Enabled)
+                        joinedList = joinedList.ReplaceRstarColorsWith("~c~");
+                    if (ParentColumn.Parent is MainView lobby)
+                    {
+                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                    }
+                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                    {
+                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                    }
+                }
             }
         }
 
@@ -202,19 +228,23 @@ namespace ScaleformUI.Menu
             _items = null;
             _items = new(list);
             Index = index;
-            //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-            //{
-            //    if (ParentColumn.Parent is MainView lobby)
-            //    {
-            //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-            //    }
-            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-            //    {
-            //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-            //    }
-            //}
+            if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+            {
+                string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
+                  x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
+                ));
+                if (!Enabled)
+                    joinedList = joinedList.ReplaceRstarColorsWith("~c~");
+                if (ParentColumn.Parent is MainView lobby)
+                {
+                    lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                }
+                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                {
+                    pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                }
+            }
         }
-
 
         public override void SetRightBadge(BadgeIcon badge)
         {

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuListItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuListItem.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace ScaleformUI.Menu
 {
-    public class UIMenuListItem : UIMenuItem, IListItem
+    public class UIMenuListItem : UIMenuDynamicListItem, IListItem
     {
         protected internal int _index;
         protected internal List<dynamic> _items;
@@ -33,13 +33,12 @@ namespace ScaleformUI.Menu
             set
             {
                 if (value < 0)
-                    _index = 0;
-                else if (value > Items.Count - 1)
                     _index = Items.Count - 1;
+                else if (value > Items.Count - 1)
+                    _index = 0;
                 else
                     _index = value;
-                if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                    Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _index);
+                CurrentListItem = Items[_index].ToString();
             }
         }
 
@@ -51,28 +50,8 @@ namespace ScaleformUI.Menu
             get => _items;
             set
             {
-                Index = 0;
                 _items = new(value);
-                string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
-                    x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
-                ));
-                if (!Enabled)
-                    joinedList = joinedList.ReplaceRstarColorsWith("~c~");
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), joinedList, Index);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                }
+                CurrentListItem = Items[_index].ToString();
             }
         }
 
@@ -82,26 +61,19 @@ namespace ScaleformUI.Menu
             set
             {
                 base.Enabled = value;
-                string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
-                    x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
-                ));
-                if (!Enabled)
-                    joinedList = joinedList.ReplaceRstarColorsWith("~c~");
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), joinedList, this.Index);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //    {
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                //    }
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //    {
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                //    }
+                //}
             }
         }
 
@@ -111,26 +83,19 @@ namespace ScaleformUI.Menu
             internal set
             {
                 base.Selected = value;
-                string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
-                    x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
-                ));
-                if (!Enabled)
-                    joinedList = joinedList.ReplaceRstarColorsWith("~c~");
-                if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), joinedList, Index);
-                }
-                if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-                {
-                    if (ParentColumn.Parent is MainView lobby)
-                    {
-                        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                    {
-                        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                    }
-                }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+                //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+                //{
+                //    if (ParentColumn.Parent is MainView lobby)
+                //    {
+                //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                //    }
+                //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+                //    {
+                //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+                //    }
+                //}
             }
         }
 
@@ -156,17 +121,34 @@ namespace ScaleformUI.Menu
         {
         }
 
-        public UIMenuListItem(string text, List<dynamic> items, int index, string description, SColor mainColor, SColor higlightColor) : this(text, items, index, description, mainColor, higlightColor, SColor.White, SColor.Black)
+        private DynamicListItemChangeCallback _callback = async (sender, direction) =>
         {
-        }
+            return await ((UIMenuListItem)sender).getIndex(direction);
+        };
 
-        public UIMenuListItem(string text, List<dynamic> items, int index, string description, SColor mainColor, SColor higlightColor, SColor textColor, SColor highlightTextColor) : base(text, description, mainColor, higlightColor, textColor, highlightTextColor)
+        public UIMenuListItem(string text, List<object> items, int index, string description, SColor mainColor, SColor higlightColor) : base(text, description, "" + items[index])
         {
             _items = new(items);
             Index = index;
-            _itemId = 1;
+            Callback = _callback;
         }
 
+        private async Task<string> getIndex(ChangeDirection d)
+        {
+            if (d == ChangeDirection.Left)
+            {
+                _index--;
+                if(_index < 0)
+                    _index = Items.Count - 1;
+            }
+            else
+            {
+                _index++;
+                if (_index >= Items.Count)
+                    _index = 0;
+            }
+            return Items[_index].ToString();
+        }
 
         /// <summary>
         /// Find an item in the list and return it's index.
@@ -220,26 +202,17 @@ namespace ScaleformUI.Menu
             _items = null;
             _items = new(list);
             Index = index;
-            string joinedList = string.Join(",", Items.Cast<string>().Select(x =>
-                x = Selected ? (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~w~", "~l~").Replace("~s~", "~l~") : (x.StartsWith("~") ? x : "~s~" + x).ToString().Replace("~l~", "~s~")
-            ));
-            if (!Enabled)
-                joinedList = joinedList.ReplaceRstarColorsWith("~c~");
-            if (Parent != null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-            {
-                Main.scaleformUI.CallFunction("UPDATE_LISTITEM_LIST", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), joinedList, Index);
-            }
-            if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
-            {
-                if (ParentColumn.Parent is MainView lobby)
-                {
-                    lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                }
-                else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
-                {
-                    pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
-                }
-            }
+            //if (ParentColumn != null && ParentColumn.Parent.Visible && ParentColumn.Pagination.IsItemVisible(ParentColumn.Items.IndexOf(this)))
+            //{
+            //    if (ParentColumn.Parent is MainView lobby)
+            //    {
+            //        lobby._pause._lobby.CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+            //    }
+            //    else if (ParentColumn.Parent is TabView pause && ParentColumn.ParentTab.Visible)
+            //    {
+            //        pause._pause._pause.CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", ParentColumn.Pagination.GetScaleformIndex(ParentColumn.Items.IndexOf(this)), joinedList, Index);
+            //    }
+            //}
         }
 
 
@@ -253,7 +226,7 @@ namespace ScaleformUI.Menu
             throw new Exception("UIMenuListItem cannot have a right label.");
         }
 
-        [Obsolete("Use UIMenuListItem.Items[Index].ToString() instead.")]
+        [Obsolete("Use CurrentListItem instead.")]
         public string CurrentItem()
         {
             return _items[Index].ToString();

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuProgressItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuProgressItem.cs
@@ -18,6 +18,8 @@ namespace ScaleformUI.Menu
             set
             {
                 sliderColor = value;
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
                 //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
                 //{
                 //    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor.ArgbValue, HighlightColor.ArgbValue, TextColor, HighlightedTextColor, value);
@@ -58,16 +60,21 @@ namespace ScaleformUI.Menu
                     _value = 0;
                 else
                     _value = value;
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
                 ProgressChanged(Value);
-                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                //    Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _value);
             }
         }
 
         public int Multiplier
         {
             get => _multiplier;
-            set => _multiplier = value;
+            set
+            {
+                _multiplier = value;
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
+            }
         }
 
         /// <summary>

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuProgressItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuProgressItem.cs
@@ -20,10 +20,6 @@ namespace ScaleformUI.Menu
                 sliderColor = value;
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
-                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                //{
-                //    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor.ArgbValue, HighlightColor.ArgbValue, TextColor, HighlightedTextColor, value);
-                //}
             }
         }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuProgressItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuProgressItem.cs
@@ -18,10 +18,10 @@ namespace ScaleformUI.Menu
             set
             {
                 sliderColor = value;
-                if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor.ArgbValue, HighlightColor.ArgbValue, TextColor, HighlightedTextColor, value);
-                }
+                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
+                //{
+                //    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor.ArgbValue, HighlightColor.ArgbValue, TextColor, HighlightedTextColor, value);
+                //}
             }
         }
 
@@ -59,8 +59,8 @@ namespace ScaleformUI.Menu
                 else
                     _value = value;
                 ProgressChanged(Value);
-                if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                    Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _value);
+                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
+                //    Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _value);
             }
         }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuSliderItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuSliderItem.cs
@@ -70,8 +70,6 @@ namespace ScaleformUI.Menu
                 if (Parent != null && Parent.Visible)
                     Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
                 SliderChanged(_value);
-                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                //    Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _value);
             }
         }
         /// <summary>

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuSliderItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuSliderItem.cs
@@ -13,10 +13,10 @@ namespace ScaleformUI.Menu
             set
             {
                 sliderColor = value;
-                if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor, HighlightColor, TextColor, HighlightedTextColor, value);
-                }
+                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
+                //{
+                //    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor, HighlightColor, TextColor, HighlightedTextColor, value);
+                //}
             }
         }
         internal bool _heritage;
@@ -64,8 +64,8 @@ namespace ScaleformUI.Menu
                 else
                     _value = value;
                 SliderChanged(_value);
-                if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                    Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _value);
+                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
+                //    Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _value);
             }
         }
         /// <summary>

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuSliderItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuSliderItem.cs
@@ -13,6 +13,8 @@ namespace ScaleformUI.Menu
             set
             {
                 sliderColor = value;
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
                 //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
                 //{
                 //    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor, HighlightColor, TextColor, HighlightedTextColor, value);
@@ -44,6 +46,8 @@ namespace ScaleformUI.Menu
                 {
                     _value = value;
                 }
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
             }
         }
         /// <summary>
@@ -63,6 +67,8 @@ namespace ScaleformUI.Menu
                     _value = 0;
                 else
                     _value = value;
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
                 SliderChanged(_value);
                 //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
                 //    Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), _value);
@@ -80,6 +86,8 @@ namespace ScaleformUI.Menu
             set
             {
                 _multiplier = value;
+                if (Parent != null && Parent.Visible)
+                    Parent.SendItemToScaleform(Parent.MenuItems.IndexOf(this), true);
             }
         }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuStatsItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuStatsItem.cs
@@ -24,10 +24,10 @@ namespace ScaleformUI.Menu
             set
             {
                 sliderColor = value;
-                if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                {
-                    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor, HighlightColor, TextColor, HighlightedTextColor, value);
-                }
+                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
+                //{
+                //    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor, HighlightColor, TextColor, HighlightedTextColor, value);
+                //}
             }
         }
 
@@ -47,7 +47,7 @@ namespace ScaleformUI.Menu
 
         public void SetValue(int value)
         {
-            Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), value);
+            //Main.scaleformUI.CallFunction("SET_ITEM_VALUE", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), value);
             OnStatChanged?.Invoke(value);
         }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuStatsItem.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Items/UIMenuStatsItem.cs
@@ -24,10 +24,6 @@ namespace ScaleformUI.Menu
             set
             {
                 sliderColor = value;
-                //if (Parent is not null && Parent.Visible && Parent.Pagination.IsItemVisible(Parent.MenuItems.IndexOf(this)))
-                //{
-                //    Main.scaleformUI.CallFunction("UPDATE_COLORS", Parent.Pagination.GetScaleformIndex(Parent.MenuItems.IndexOf(this)), MainColor, HighlightColor, TextColor, HighlightedTextColor, value);
-                //}
             }
         }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColorPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColorPanel.cs
@@ -71,10 +71,10 @@ namespace ScaleformUI.Menu
 
         private async void _getValue()
         {
-            int it = this.ParentItem.Parent.Pagination.GetScaleformIndex(this.ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
+            //int it = this.ParentItem.Parent.Pagination.GetScaleformIndex(this.ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
             int van = this.ParentItem.Panels.IndexOf(this);
             API.BeginScaleformMovieMethod(Main.scaleformUI.Handle, "GET_VALUE_FROM_PANEL");
-            API.ScaleformMovieMethodAddParamInt(it);
+            //API.ScaleformMovieMethodAddParamInt(it);
             API.ScaleformMovieMethodAddParamInt(van);
             int ret = API.EndScaleformMovieMethodReturnValue();
             while (!API.IsScaleformMovieMethodReturnValueReady(ret)) await BaseScript.Delay(0);
@@ -84,12 +84,12 @@ namespace ScaleformUI.Menu
         public void _setValue(int val)
         {
 
-            if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            {
-                int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-                int van = ParentItem.Panels.IndexOf(this);
-                Main.scaleformUI.CallFunction("SET_COLOR_PANEL_VALUE", it, van, val);
-            }
+            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
+            //{
+            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
+            //    int van = ParentItem.Panels.IndexOf(this);
+            //    Main.scaleformUI.CallFunction("SET_COLOR_PANEL_VALUE", it, van, val);
+            //}
         }
     }
 }

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColorPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColorPanel.cs
@@ -36,7 +36,11 @@ namespace ScaleformUI.Menu
                     if (value < 0)
                         _value += CustomColors.Count - 1;
                 }
-                _setValue(_value);
+                if (ParentItem != null && ParentItem.Parent != null)
+                {
+                    int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                    ParentItem.Parent.SendPanelsToItemScaleform(it, true);
+                }
             }
         }
         public UIMenuColorPanel(string title, ColorPanelType ColorType, int startIndex = 0)
@@ -79,17 +83,6 @@ namespace ScaleformUI.Menu
             int ret = API.EndScaleformMovieMethodReturnValue();
             while (!API.IsScaleformMovieMethodReturnValueReady(ret)) await BaseScript.Delay(0);
             _value = API.GetScaleformMovieMethodReturnValueInt(ret);
-        }
-
-        public void _setValue(int val)
-        {
-
-            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            //{
-            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-            //    int van = ParentItem.Panels.IndexOf(this);
-            //    Main.scaleformUI.CallFunction("SET_COLOR_PANEL_VALUE", it, van, val);
-            //}
         }
     }
 }

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColorPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColorPanel.cs
@@ -36,10 +36,12 @@ namespace ScaleformUI.Menu
                     if (value < 0)
                         _value += CustomColors.Count - 1;
                 }
-                if (ParentItem != null && ParentItem.Parent != null)
+                if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible)
                 {
                     int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
                     ParentItem.Parent.SendPanelsToItemScaleform(it, true);
+                    PanelChanged();
+                    ParentItem.Parent.ColorPanelChange(ParentItem, this, _value);
                 }
             }
         }
@@ -61,28 +63,6 @@ namespace ScaleformUI.Menu
         internal void PanelChanged()
         {
             OnColorPanelChange?.Invoke(ParentItem, this, CurrentSelection);
-        }
-
-        /*
-        private void //UpdateSelection(bool update)
-        {
-            if (update)
-            {
-                ParentItem.Parent.ListChange(ParentItem, ParentItem.Index);
-                ParentItem.ListChangedTrigger(ParentItem.Index);
-            }
-        }*/
-
-        private async void _getValue()
-        {
-            //int it = this.ParentItem.Parent.Pagination.GetScaleformIndex(this.ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-            int van = this.ParentItem.Panels.IndexOf(this);
-            API.BeginScaleformMovieMethod(Main.scaleformUI.Handle, "GET_VALUE_FROM_PANEL");
-            //API.ScaleformMovieMethodAddParamInt(it);
-            API.ScaleformMovieMethodAddParamInt(van);
-            int ret = API.EndScaleformMovieMethodReturnValue();
-            while (!API.IsScaleformMovieMethodReturnValueReady(ret)) await BaseScript.Delay(0);
-            _value = API.GetScaleformMovieMethodReturnValueInt(ret);
         }
     }
 }

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColourPickePanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColourPickePanel.cs
@@ -47,12 +47,12 @@ namespace ScaleformUI.Menu
 
         internal void _setValue(int val)
         {
-            if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            {
-                int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-                int van = ParentItem.Panels.IndexOf(this);
-                Main.scaleformUI.CallFunction("SET_COLOR_PICKER_PANEL_VALUE", it, van, val);
-            }
+            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
+            //{
+            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
+            //    int van = ParentItem.Panels.IndexOf(this);
+            //    Main.scaleformUI.CallFunction("SET_COLOR_PICKER_PANEL_VALUE", it, van, val);
+            //}
         }
 
         internal void PickerHovered(int colorId, SColor color)

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColourPickePanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColourPickePanel.cs
@@ -47,12 +47,11 @@ namespace ScaleformUI.Menu
 
         internal void _setValue(int val)
         {
-            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            //{
-            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-            //    int van = ParentItem.Panels.IndexOf(this);
-            //    Main.scaleformUI.CallFunction("SET_COLOR_PICKER_PANEL_VALUE", it, van, val);
-            //}
+            if (ParentItem != null && ParentItem.Parent != null)
+            {
+                int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                ParentItem.Parent.SendPanelsToItemScaleform(it, true);
+            }
         }
 
         internal void PickerHovered(int colorId, SColor color)

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColourPickePanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuColourPickePanel.cs
@@ -47,7 +47,7 @@ namespace ScaleformUI.Menu
 
         internal void _setValue(int val)
         {
-            if (ParentItem != null && ParentItem.Parent != null)
+            if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible)
             {
                 int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
                 ParentItem.Parent.SendPanelsToItemScaleform(it, true);

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuGridPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuGridPanel.cs
@@ -30,10 +30,12 @@ namespace ScaleformUI.Menu
             set
             {
                 _value = value;
-                if (ParentItem != null && ParentItem.Parent != null)
+                if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible)
                 {
                     int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
                     ParentItem.Parent.SendPanelsToItemScaleform(it, true);
+                    OnGridChange();
+                    ParentItem.Parent.GridPanelChange(ParentItem, this, _value);
                 }
             }
         }
@@ -70,29 +72,6 @@ namespace ScaleformUI.Menu
             RightLabel = RightText ?? "Right";
             GridType = GridType.Horizontal;
             _value = circlePosition;
-        }
-
-        /*
-        internal void UpdateParent( float X, float Y)
-        {
-            ParentItem.Parent.ListChange(ParentItem, ParentItem.Index);
-            ParentItem.ListChangedTrigger(ParentItem.Index);
-        }*/
-
-        private async void SetMousePosition(PointF mouse)
-        {
-            //int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-            //int van = ParentItem.Panels.IndexOf(this);
-            //API.BeginScaleformMovieMethod(Main.scaleformUI.Handle, "SET_GRID_PANEL_POSITION_RETURN_VALUE");
-            //API.ScaleformMovieMethodAddParamInt(0);
-            //API.ScaleformMovieMethodAddParamInt(1);
-            //API.ScaleformMovieMethodAddParamFloat(mouse.X);
-            //API.ScaleformMovieMethodAddParamFloat(mouse.Y);
-            //int ret = API.EndScaleformMovieMethodReturnValue();
-            //while (!API.IsScaleformMovieMethodReturnValueReady(ret)) await BaseScript.Delay(0);
-            //string res = API.GetScaleformMovieMethodReturnValueString(ret);
-            //string[] returned = res.Split(',');
-            //_value = new PointF(Convert.ToSingle(returned[0]), Convert.ToSingle(returned[1]));
         }
 
         internal void OnGridChange()

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuGridPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuGridPanel.cs
@@ -30,7 +30,11 @@ namespace ScaleformUI.Menu
             set
             {
                 _value = value;
-                _setValue(value);
+                if (ParentItem != null && ParentItem.Parent != null)
+                {
+                    int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                    ParentItem.Parent.SendPanelsToItemScaleform(it, true);
+                }
             }
         }
 
@@ -74,16 +78,6 @@ namespace ScaleformUI.Menu
             ParentItem.Parent.ListChange(ParentItem, ParentItem.Index);
             ParentItem.ListChangedTrigger(ParentItem.Index);
         }*/
-
-        private void _setValue(PointF value)
-        {
-            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            //{
-            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-            //    int van = ParentItem.Panels.IndexOf(this);
-            //    Main.scaleformUI.CallFunction("SET_GRID_PANEL_VALUE_RETURN_VALUE", it, van, value.X, value.Y);
-            //}
-        }
 
         private async void SetMousePosition(PointF mouse)
         {

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuGridPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuGridPanel.cs
@@ -77,28 +77,28 @@ namespace ScaleformUI.Menu
 
         private void _setValue(PointF value)
         {
-            if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            {
-                int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-                int van = ParentItem.Panels.IndexOf(this);
-                Main.scaleformUI.CallFunction("SET_GRID_PANEL_VALUE_RETURN_VALUE", it, van, value.X, value.Y);
-            }
+            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
+            //{
+            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
+            //    int van = ParentItem.Panels.IndexOf(this);
+            //    Main.scaleformUI.CallFunction("SET_GRID_PANEL_VALUE_RETURN_VALUE", it, van, value.X, value.Y);
+            //}
         }
 
         private async void SetMousePosition(PointF mouse)
         {
-            int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-            int van = ParentItem.Panels.IndexOf(this);
-            API.BeginScaleformMovieMethod(Main.scaleformUI.Handle, "SET_GRID_PANEL_POSITION_RETURN_VALUE");
-            API.ScaleformMovieMethodAddParamInt(0);
-            API.ScaleformMovieMethodAddParamInt(1);
-            API.ScaleformMovieMethodAddParamFloat(mouse.X);
-            API.ScaleformMovieMethodAddParamFloat(mouse.Y);
-            int ret = API.EndScaleformMovieMethodReturnValue();
-            while (!API.IsScaleformMovieMethodReturnValueReady(ret)) await BaseScript.Delay(0);
-            string res = API.GetScaleformMovieMethodReturnValueString(ret);
-            string[] returned = res.Split(',');
-            _value = new PointF(Convert.ToSingle(returned[0]), Convert.ToSingle(returned[1]));
+            //int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
+            //int van = ParentItem.Panels.IndexOf(this);
+            //API.BeginScaleformMovieMethod(Main.scaleformUI.Handle, "SET_GRID_PANEL_POSITION_RETURN_VALUE");
+            //API.ScaleformMovieMethodAddParamInt(0);
+            //API.ScaleformMovieMethodAddParamInt(1);
+            //API.ScaleformMovieMethodAddParamFloat(mouse.X);
+            //API.ScaleformMovieMethodAddParamFloat(mouse.Y);
+            //int ret = API.EndScaleformMovieMethodReturnValue();
+            //while (!API.IsScaleformMovieMethodReturnValueReady(ret)) await BaseScript.Delay(0);
+            //string res = API.GetScaleformMovieMethodReturnValueString(ret);
+            //string[] returned = res.Split(',');
+            //_value = new PointF(Convert.ToSingle(returned[0]), Convert.ToSingle(returned[1]));
         }
 
         internal void OnGridChange()

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuPercentagePanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuPercentagePanel.cs
@@ -47,25 +47,25 @@ namespace ScaleformUI.Menu
 
         private void _setValue(float val)
         {
-            if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            {
-                int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-                int van = ParentItem.Panels.IndexOf(this);
-                Main.scaleformUI.CallFunction("SET_PERCENT_PANEL_RETURN_VALUE", it, van, val);
-            }
+            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
+            //{
+            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
+            //    int van = ParentItem.Panels.IndexOf(this);
+            //    Main.scaleformUI.CallFunction("SET_PERCENT_PANEL_RETURN_VALUE", it, van, val);
+            //}
         }
 
         private async void SetMousePercentage(PointF mouse)
         {
-            int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-            int van = ParentItem.Panels.IndexOf(this);
-            API.BeginScaleformMovieMethod(Main.scaleformUI.Handle, "SET_PERCENT_PANEL_POSITION_RETURN_VALUE");
-            API.ScaleformMovieMethodAddParamInt(it);
-            API.ScaleformMovieMethodAddParamInt(van);
-            API.ScaleformMovieMethodAddParamFloat(mouse.X);
-            int ret = API.EndScaleformMovieMethodReturnValue();
-            while (!API.IsScaleformMovieMethodReturnValueReady(ret)) await BaseScript.Delay(0);
-            _value = Convert.ToSingle(API.GetScaleformMovieMethodReturnValueString(ret));
+            //int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
+            //int van = ParentItem.Panels.IndexOf(this);
+            //API.BeginScaleformMovieMethod(Main.scaleformUI.Handle, "SET_PERCENT_PANEL_POSITION_RETURN_VALUE");
+            //API.ScaleformMovieMethodAddParamInt(it);
+            //API.ScaleformMovieMethodAddParamInt(van);
+            //API.ScaleformMovieMethodAddParamFloat(mouse.X);
+            //int ret = API.EndScaleformMovieMethodReturnValue();
+            //while (!API.IsScaleformMovieMethodReturnValueReady(ret)) await BaseScript.Delay(0);
+            //_value = Convert.ToSingle(API.GetScaleformMovieMethodReturnValueString(ret));
         }
 
         internal void PercentagePanelChange()

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuPercentagePanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuPercentagePanel.cs
@@ -24,10 +24,12 @@ namespace ScaleformUI.Menu
             set
             {
                 _value = value;
-                if (ParentItem != null && ParentItem.Parent != null)
+                if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible)
                 {
                     int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
                     ParentItem.Parent.SendPanelsToItemScaleform(it, true);
+                    PercentagePanelChange();
+                    ParentItem.Parent.PercentagePanelChange(ParentItem, this, _value);
                 }
             }
         }
@@ -39,27 +41,6 @@ namespace ScaleformUI.Menu
             Max = MaxText;
             Title = !string.IsNullOrWhiteSpace(title) ? title : "Opacity";
             _value = initialValue;
-        }
-
-        /*
-        public void UpdateParent(float Percentage)
-        {
-            ParentItem.Parent.ListChange(ParentItem, ParentItem.Index);
-            ParentItem.ListChangedTrigger(ParentItem.Index);
-        }
-        */
-
-        private async void SetMousePercentage(PointF mouse)
-        {
-            //int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-            //int van = ParentItem.Panels.IndexOf(this);
-            //API.BeginScaleformMovieMethod(Main.scaleformUI.Handle, "SET_PERCENT_PANEL_POSITION_RETURN_VALUE");
-            //API.ScaleformMovieMethodAddParamInt(it);
-            //API.ScaleformMovieMethodAddParamInt(van);
-            //API.ScaleformMovieMethodAddParamFloat(mouse.X);
-            //int ret = API.EndScaleformMovieMethodReturnValue();
-            //while (!API.IsScaleformMovieMethodReturnValueReady(ret)) await BaseScript.Delay(0);
-            //_value = Convert.ToSingle(API.GetScaleformMovieMethodReturnValueString(ret));
         }
 
         internal void PercentagePanelChange()

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuPercentagePanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuPercentagePanel.cs
@@ -24,7 +24,11 @@ namespace ScaleformUI.Menu
             set
             {
                 _value = value;
-                _setValue(value);
+                if (ParentItem != null && ParentItem.Parent != null)
+                {
+                    int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                    ParentItem.Parent.SendPanelsToItemScaleform(it, true);
+                }
             }
         }
 
@@ -44,16 +48,6 @@ namespace ScaleformUI.Menu
             ParentItem.ListChangedTrigger(ParentItem.Index);
         }
         */
-
-        private void _setValue(float val)
-        {
-            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            //{
-            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-            //    int van = ParentItem.Panels.IndexOf(this);
-            //    Main.scaleformUI.CallFunction("SET_PERCENT_PANEL_RETURN_VALUE", it, van, val);
-            //}
-        }
 
         private async void SetMousePercentage(PointF mouse)
         {

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuStatisticsPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuStatisticsPanel.cs
@@ -1,4 +1,6 @@
-﻿namespace ScaleformUI.Menu
+﻿using System.Reflection.Emit;
+
+namespace ScaleformUI.Menu
 {
     public class UIMenuStatisticsPanel : UIMenuPanel
     {
@@ -18,12 +20,11 @@
                 _value = 0;
             StatisticsForPanel item = new(Name, _value);
             Items.Add(item);
-            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            //{
-            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-            //    int van = ParentItem.Panels.IndexOf(this);
-            //    Main.scaleformUI.CallFunction("ADD_STATISTIC_TO_PANEL", it, van, Name, _value);
-            //}
+            if (ParentItem != null && ParentItem.Parent != null)
+            {
+                int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                ParentItem.Parent.SendPanelsToItemScaleform(it, true);
+            }
         }
 
         public float GetPercentage(int ItemId)
@@ -38,12 +39,11 @@
                 Items[ItemId].Value = 100;
             if (Items[ItemId].Value < 0)
                 Items[ItemId].Value = 0;
-            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            //{
-            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-            //    int van = ParentItem.Panels.IndexOf(this);
-            //    Main.scaleformUI.CallFunction("SET_PANEL_STATS_ITEM_VALUE", it, van, ItemId, Items[ItemId].Value);
-            //}
+            if (ParentItem != null && ParentItem.Parent != null)
+            {
+                int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                ParentItem.Parent.SendPanelsToItemScaleform(it, true);
+            }
         }
     }
 
@@ -60,6 +60,11 @@
                 Value = 100;
             if (Value < 0)
                 Value = 0;
+        }
+
+        public override string ToString()
+        {
+            return $"{Text}:{Value}";
         }
     }
 }

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuStatisticsPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuStatisticsPanel.cs
@@ -18,12 +18,12 @@
                 _value = 0;
             StatisticsForPanel item = new(Name, _value);
             Items.Add(item);
-            if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            {
-                int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-                int van = ParentItem.Panels.IndexOf(this);
-                Main.scaleformUI.CallFunction("ADD_STATISTIC_TO_PANEL", it, van, Name, _value);
-            }
+            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
+            //{
+            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
+            //    int van = ParentItem.Panels.IndexOf(this);
+            //    Main.scaleformUI.CallFunction("ADD_STATISTIC_TO_PANEL", it, van, Name, _value);
+            //}
         }
 
         public float GetPercentage(int ItemId)
@@ -38,12 +38,12 @@
                 Items[ItemId].Value = 100;
             if (Items[ItemId].Value < 0)
                 Items[ItemId].Value = 0;
-            if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
-            {
-                int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
-                int van = ParentItem.Panels.IndexOf(this);
-                Main.scaleformUI.CallFunction("SET_PANEL_STATS_ITEM_VALUE", it, van, ItemId, Items[ItemId].Value);
-            }
+            //if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible && ParentItem.Parent.Pagination.IsItemVisible(ParentItem.Parent.MenuItems.IndexOf(ParentItem)))
+            //{
+            //    int it = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(ParentItem));
+            //    int van = ParentItem.Panels.IndexOf(this);
+            //    Main.scaleformUI.CallFunction("SET_PANEL_STATS_ITEM_VALUE", it, van, ItemId, Items[ItemId].Value);
+            //}
         }
     }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuStatisticsPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Panels/UIMenuStatisticsPanel.cs
@@ -39,7 +39,7 @@ namespace ScaleformUI.Menu
                 Items[ItemId].Value = 100;
             if (Items[ItemId].Value < 0)
                 Items[ItemId].Value = 0;
-            if (ParentItem != null && ParentItem.Parent != null)
+            if (ParentItem != null && ParentItem.Parent != null && ParentItem.Parent.Visible)
             {
                 int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
                 ParentItem.Parent.SendPanelsToItemScaleform(it, true);

--- a/ScaleformUI_Csharp/Menus/UIMenu/SidePanels/ColorPicker/UIVehicleColourPickerPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/SidePanels/ColorPicker/UIVehicleColourPickerPanel.cs
@@ -15,7 +15,8 @@ namespace ScaleformUI.Menu
                 title = value;
                 if (ParentItem is not null && ParentItem.Parent != null && ParentItem.Parent.Visible)
                 {
-                    //Main.scaleformUI.CallFunction("UPDATE_SIDE_PANEL_TITLE", ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem)), title);
+                    int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                    ParentItem.Parent.SendSidePanelToScaleform(it, true);
                 }
             }
         }

--- a/ScaleformUI_Csharp/Menus/UIMenu/SidePanels/ColorPicker/UIVehicleColourPickerPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/SidePanels/ColorPicker/UIVehicleColourPickerPanel.cs
@@ -15,7 +15,7 @@ namespace ScaleformUI.Menu
                 title = value;
                 if (ParentItem is not null && ParentItem.Parent != null && ParentItem.Parent.Visible)
                 {
-                    Main.scaleformUI.CallFunction("UPDATE_SIDE_PANEL_TITLE", ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem)), title);
+                    //Main.scaleformUI.CallFunction("UPDATE_SIDE_PANEL_TITLE", ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem)), title);
                 }
             }
         }

--- a/ScaleformUI_Csharp/Menus/UIMenu/SidePanels/DetailsPanel/UIMissionDetailsPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/SidePanels/DetailsPanel/UIMissionDetailsPanel.cs
@@ -16,7 +16,7 @@ namespace ScaleformUI.Menu
                 title = value;
                 if (ParentItem is not null && ParentItem.Parent != null && ParentItem.Parent.Visible)
                 {
-                    Main.scaleformUI.CallFunction("UPDATE_SIDE_PANEL_TITLE", ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem)), title);
+                    //Main.scaleformUI.CallFunction("UPDATE_SIDE_PANEL_TITLE", ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem)), title);
                 }
             }
         }
@@ -73,8 +73,8 @@ namespace ScaleformUI.Menu
             TextureName = txn;
             if (ParentItem is not null)
             {
-                int wid = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-                Main.scaleformUI.CallFunction("UPDATE_MISSION_DETAILS_PANEL_IMG", wid, TextureDict, TextureName);
+                //int wid = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
+                //Main.scaleformUI.CallFunction("UPDATE_MISSION_DETAILS_PANEL_IMG", wid, TextureDict, TextureName);
             }
 
         }
@@ -88,8 +88,8 @@ namespace ScaleformUI.Menu
             Items.Add(item);
             if (ParentItem is not null && ParentItem.Parent != null && ParentItem.Parent.Visible)
             {
-                int wid = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-                Main.scaleformUI.CallFunction("ADD_MISSION_DETAILS_DESC_ITEM", wid, item.Type, item.TextLeft, item.TextRight, (int)item.Icon, item.IconColor, item.Tick, item._labelFont.FontName, item._labelFont.FontID, item._rightLabelFont.FontName, item._rightLabelFont.FontID);
+                //int wid = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
+                //Main.scaleformUI.CallFunction("ADD_MISSION_DETAILS_DESC_ITEM", wid, item.Type, item.TextLeft, item.TextRight, (int)item.Icon, item.IconColor, item.Tick, item._labelFont.FontName, item._labelFont.FontID, item._rightLabelFont.FontName, item._rightLabelFont.FontID);
             }
         }
 
@@ -102,8 +102,8 @@ namespace ScaleformUI.Menu
             Items.RemoveAt(idx);
             if (ParentItem is not null && ParentItem.Parent != null && ParentItem.Parent.Visible)
             {
-                int wid = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-                Main.scaleformUI.CallFunction("REMOVE_MISSION_DETAILS_DESC_ITEM", wid, idx);
+                //int wid = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
+                //Main.scaleformUI.CallFunction("REMOVE_MISSION_DETAILS_DESC_ITEM", wid, idx);
             }
         }
     }

--- a/ScaleformUI_Csharp/Menus/UIMenu/SidePanels/DetailsPanel/UIMissionDetailsPanel.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/SidePanels/DetailsPanel/UIMissionDetailsPanel.cs
@@ -16,7 +16,8 @@ namespace ScaleformUI.Menu
                 title = value;
                 if (ParentItem is not null && ParentItem.Parent != null && ParentItem.Parent.Visible)
                 {
-                    //Main.scaleformUI.CallFunction("UPDATE_SIDE_PANEL_TITLE", ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem)), title);
+                    int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                    ParentItem.Parent.SendSidePanelToScaleform(it, true);
                 }
             }
         }
@@ -71,10 +72,10 @@ namespace ScaleformUI.Menu
         {
             TextureDict = txd;
             TextureName = txn;
-            if (ParentItem is not null)
+            if (ParentItem is not null && ParentItem.Parent != null && ParentItem.Parent.Visible)
             {
-                //int wid = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-                //Main.scaleformUI.CallFunction("UPDATE_MISSION_DETAILS_PANEL_IMG", wid, TextureDict, TextureName);
+                int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                ParentItem.Parent.SendSidePanelToScaleform(it, true);
             }
 
         }
@@ -88,8 +89,8 @@ namespace ScaleformUI.Menu
             Items.Add(item);
             if (ParentItem is not null && ParentItem.Parent != null && ParentItem.Parent.Visible)
             {
-                //int wid = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-                //Main.scaleformUI.CallFunction("ADD_MISSION_DETAILS_DESC_ITEM", wid, item.Type, item.TextLeft, item.TextRight, (int)item.Icon, item.IconColor, item.Tick, item._labelFont.FontName, item._labelFont.FontID, item._rightLabelFont.FontName, item._rightLabelFont.FontID);
+                int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                ParentItem.Parent.SendSidePanelToScaleform(it, true);
             }
         }
 
@@ -102,8 +103,8 @@ namespace ScaleformUI.Menu
             Items.RemoveAt(idx);
             if (ParentItem is not null && ParentItem.Parent != null && ParentItem.Parent.Visible)
             {
-                //int wid = ParentItem.Parent.Pagination.GetScaleformIndex(ParentItem.Parent.MenuItems.IndexOf(this.ParentItem));
-                //Main.scaleformUI.CallFunction("REMOVE_MISSION_DETAILS_DESC_ITEM", wid, idx);
+                int it = ParentItem.Parent.MenuItems.IndexOf(ParentItem);
+                ParentItem.Parent.SendSidePanelToScaleform(it, true);
             }
         }
     }

--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -17,788 +17,6 @@ using Control = CitizenFX.Core.Control;
 namespace ScaleformUI.Menu
 {
     #region Delegates
-    public enum Keys
-    {
-        //
-        // Summary:
-        //     The bitmask to extract modifiers from a key value.
-        Modifiers = -65536,
-        //
-        // Summary:
-        //     No key pressed.
-        None = 0,
-        //
-        // Summary:
-        //     The left mouse button.
-        LButton = 1,
-        //
-        // Summary:
-        //     The right mouse button.
-        RButton = 2,
-        //
-        // Summary:
-        //     The CANCEL key.
-        Cancel = 3,
-        //
-        // Summary:
-        //     The middle mouse button (three-button mouse).
-        MButton = 4,
-        //
-        // Summary:
-        //     The first x mouse button (five-button mouse).
-        XButton1 = 5,
-        //
-        // Summary:
-        //     The second x mouse button (five-button mouse).
-        XButton2 = 6,
-        //
-        // Summary:
-        //     The BACKSPACE key.
-        Back = 8,
-        //
-        // Summary:
-        //     The TAB key.
-        Tab = 9,
-        //
-        // Summary:
-        //     The LINEFEED key.
-        LineFeed = 10,
-        //
-        // Summary:
-        //     The CLEAR key.
-        Clear = 12,
-        //
-        // Summary:
-        //     The RETURN key.
-        Return = 13,
-        //
-        // Summary:
-        //     The ENTER key.
-        Enter = 13,
-        //
-        // Summary:
-        //     The SHIFT key.
-        ShiftKey = 16,
-        //
-        // Summary:
-        //     The CTRL key.
-        ControlKey = 17,
-        //
-        // Summary:
-        //     The ALT key.
-        Menu = 18,
-        //
-        // Summary:
-        //     The PAUSE key.
-        Pause = 19,
-        //
-        // Summary:
-        //     The CAPS LOCK key.
-        Capital = 20,
-        //
-        // Summary:
-        //     The CAPS LOCK key.
-        CapsLock = 20,
-        //
-        // Summary:
-        //     The IME Kana mode key.
-        KanaMode = 21,
-        //
-        // Summary:
-        //     The IME Hanguel mode key. (maintained for compatibility; use HangulMode)
-        HanguelMode = 21,
-        //
-        // Summary:
-        //     The IME Hangul mode key.
-        HangulMode = 21,
-        //
-        // Summary:
-        //     The IME Junja mode key.
-        JunjaMode = 23,
-        //
-        // Summary:
-        //     The IME final mode key.
-        FinalMode = 24,
-        //
-        // Summary:
-        //     The IME Hanja mode key.
-        HanjaMode = 25,
-        //
-        // Summary:
-        //     The IME Kanji mode key.
-        KanjiMode = 25,
-        //
-        // Summary:
-        //     The ESC key.
-        Escape = 27,
-        //
-        // Summary:
-        //     The IME convert key.
-        IMEConvert = 28,
-        //
-        // Summary:
-        //     The IME nonconvert key.
-        IMENonconvert = 29,
-        //
-        // Summary:
-        //     The IME accept key, replaces System.Windows.Forms.Keys.IMEAceept.
-        IMEAccept = 30,
-        //
-        // Summary:
-        //     The IME accept key. Obsolete, use System.Windows.Forms.Keys.IMEAccept instead.
-        IMEAceept = 30,
-        //
-        // Summary:
-        //     The IME mode change key.
-        IMEModeChange = 31,
-        //
-        // Summary:
-        //     The SPACEBAR key.
-        Space = 32,
-        //
-        // Summary:
-        //     The PAGE UP key.
-        Prior = 33,
-        //
-        // Summary:
-        //     The PAGE UP key.
-        PageUp = 33,
-        //
-        // Summary:
-        //     The PAGE DOWN key.
-        Next = 34,
-        //
-        // Summary:
-        //     The PAGE DOWN key.
-        PageDown = 34,
-        //
-        // Summary:
-        //     The END key.
-        End = 35,
-        //
-        // Summary:
-        //     The HOME key.
-        Home = 36,
-        //
-        // Summary:
-        //     The LEFT ARROW key.
-        Left = 37,
-        //
-        // Summary:
-        //     The UP ARROW key.
-        Up = 38,
-        //
-        // Summary:
-        //     The RIGHT ARROW key.
-        Right = 39,
-        //
-        // Summary:
-        //     The DOWN ARROW key.
-        Down = 40,
-        //
-        // Summary:
-        //     The SELECT key.
-        Select = 41,
-        //
-        // Summary:
-        //     The PRINT key.
-        Print = 42,
-        //
-        // Summary:
-        //     The EXECUTE key.
-        Execute = 43,
-        //
-        // Summary:
-        //     The PRINT SCREEN key.
-        Snapshot = 44,
-        //
-        // Summary:
-        //     The PRINT SCREEN key.
-        PrintScreen = 44,
-        //
-        // Summary:
-        //     The INS key.
-        Insert = 45,
-        //
-        // Summary:
-        //     The DEL key.
-        Delete = 46,
-        //
-        // Summary:
-        //     The HELP key.
-        Help = 47,
-        //
-        // Summary:
-        //     The 0 key.
-        D0 = 48,
-        //
-        // Summary:
-        //     The 1 key.
-        D1 = 49,
-        //
-        // Summary:
-        //     The 2 key.
-        D2 = 50,
-        //
-        // Summary:
-        //     The 3 key.
-        D3 = 51,
-        //
-        // Summary:
-        //     The 4 key.
-        D4 = 52,
-        //
-        // Summary:
-        //     The 5 key.
-        D5 = 53,
-        //
-        // Summary:
-        //     The 6 key.
-        D6 = 54,
-        //
-        // Summary:
-        //     The 7 key.
-        D7 = 55,
-        //
-        // Summary:
-        //     The 8 key.
-        D8 = 56,
-        //
-        // Summary:
-        //     The 9 key.
-        D9 = 57,
-        //
-        // Summary:
-        //     The A key.
-        A = 65,
-        //
-        // Summary:
-        //     The B key.
-        B = 66,
-        //
-        // Summary:
-        //     The C key.
-        C = 67,
-        //
-        // Summary:
-        //     The D key.
-        D = 68,
-        //
-        // Summary:
-        //     The E key.
-        E = 69,
-        //
-        // Summary:
-        //     The F key.
-        F = 70,
-        //
-        // Summary:
-        //     The G key.
-        G = 71,
-        //
-        // Summary:
-        //     The H key.
-        H = 72,
-        //
-        // Summary:
-        //     The I key.
-        I = 73,
-        //
-        // Summary:
-        //     The J key.
-        J = 74,
-        //
-        // Summary:
-        //     The K key.
-        K = 75,
-        //
-        // Summary:
-        //     The L key.
-        L = 76,
-        //
-        // Summary:
-        //     The M key.
-        M = 77,
-        //
-        // Summary:
-        //     The N key.
-        N = 78,
-        //
-        // Summary:
-        //     The O key.
-        O = 79,
-        //
-        // Summary:
-        //     The P key.
-        P = 80,
-        //
-        // Summary:
-        //     The Q key.
-        Q = 81,
-        //
-        // Summary:
-        //     The R key.
-        R = 82,
-        //
-        // Summary:
-        //     The S key.
-        S = 83,
-        //
-        // Summary:
-        //     The T key.
-        T = 84,
-        //
-        // Summary:
-        //     The U key.
-        U = 85,
-        //
-        // Summary:
-        //     The V key.
-        V = 86,
-        //
-        // Summary:
-        //     The W key.
-        W = 87,
-        //
-        // Summary:
-        //     The X key.
-        X = 88,
-        //
-        // Summary:
-        //     The Y key.
-        Y = 89,
-        //
-        // Summary:
-        //     The Z key.
-        Z = 90,
-        //
-        // Summary:
-        //     The left Windows logo key (Microsoft Natural Keyboard).
-        LWin = 91,
-        //
-        // Summary:
-        //     The right Windows logo key (Microsoft Natural Keyboard).
-        RWin = 92,
-        //
-        // Summary:
-        //     The application key (Microsoft Natural Keyboard).
-        Apps = 93,
-        //
-        // Summary:
-        //     The computer sleep key.
-        Sleep = 95,
-        //
-        // Summary:
-        //     The 0 key on the numeric keypad.
-        NumPad0 = 96,
-        //
-        // Summary:
-        //     The 1 key on the numeric keypad.
-        NumPad1 = 97,
-        //
-        // Summary:
-        //     The 2 key on the numeric keypad.
-        NumPad2 = 98,
-        //
-        // Summary:
-        //     The 3 key on the numeric keypad.
-        NumPad3 = 99,
-        //
-        // Summary:
-        //     The 4 key on the numeric keypad.
-        NumPad4 = 100,
-        //
-        // Summary:
-        //     The 5 key on the numeric keypad.
-        NumPad5 = 101,
-        //
-        // Summary:
-        //     The 6 key on the numeric keypad.
-        NumPad6 = 102,
-        //
-        // Summary:
-        //     The 7 key on the numeric keypad.
-        NumPad7 = 103,
-        //
-        // Summary:
-        //     The 8 key on the numeric keypad.
-        NumPad8 = 104,
-        //
-        // Summary:
-        //     The 9 key on the numeric keypad.
-        NumPad9 = 105,
-        //
-        // Summary:
-        //     The multiply key.
-        Multiply = 106,
-        //
-        // Summary:
-        //     The add key.
-        Add = 107,
-        //
-        // Summary:
-        //     The separator key.
-        Separator = 108,
-        //
-        // Summary:
-        //     The subtract key.
-        Subtract = 109,
-        //
-        // Summary:
-        //     The decimal key.
-        Decimal = 110,
-        //
-        // Summary:
-        //     The divide key.
-        Divide = 111,
-        //
-        // Summary:
-        //     The F1 key.
-        F1 = 112,
-        //
-        // Summary:
-        //     The F2 key.
-        F2 = 113,
-        //
-        // Summary:
-        //     The F3 key.
-        F3 = 114,
-        //
-        // Summary:
-        //     The F4 key.
-        F4 = 115,
-        //
-        // Summary:
-        //     The F5 key.
-        F5 = 116,
-        //
-        // Summary:
-        //     The F6 key.
-        F6 = 117,
-        //
-        // Summary:
-        //     The F7 key.
-        F7 = 118,
-        //
-        // Summary:
-        //     The F8 key.
-        F8 = 119,
-        //
-        // Summary:
-        //     The F9 key.
-        F9 = 120,
-        //
-        // Summary:
-        //     The F10 key.
-        F10 = 121,
-        //
-        // Summary:
-        //     The F11 key.
-        F11 = 122,
-        //
-        // Summary:
-        //     The F12 key.
-        F12 = 123,
-        //
-        // Summary:
-        //     The F13 key.
-        F13 = 124,
-        //
-        // Summary:
-        //     The F14 key.
-        F14 = 125,
-        //
-        // Summary:
-        //     The F15 key.
-        F15 = 126,
-        //
-        // Summary:
-        //     The F16 key.
-        F16 = 127,
-        //
-        // Summary:
-        //     The F17 key.
-        F17 = 128,
-        //
-        // Summary:
-        //     The F18 key.
-        F18 = 129,
-        //
-        // Summary:
-        //     The F19 key.
-        F19 = 130,
-        //
-        // Summary:
-        //     The F20 key.
-        F20 = 131,
-        //
-        // Summary:
-        //     The F21 key.
-        F21 = 132,
-        //
-        // Summary:
-        //     The F22 key.
-        F22 = 133,
-        //
-        // Summary:
-        //     The F23 key.
-        F23 = 134,
-        //
-        // Summary:
-        //     The F24 key.
-        F24 = 135,
-        //
-        // Summary:
-        //     The NUM LOCK key.
-        NumLock = 144,
-        //
-        // Summary:
-        //     The SCROLL LOCK key.
-        Scroll = 145,
-        //
-        // Summary:
-        //     The left SHIFT key.
-        LShiftKey = 160,
-        //
-        // Summary:
-        //     The right SHIFT key.
-        RShiftKey = 161,
-        //
-        // Summary:
-        //     The left CTRL key.
-        LControlKey = 162,
-        //
-        // Summary:
-        //     The right CTRL key.
-        RControlKey = 163,
-        //
-        // Summary:
-        //     The left ALT key.
-        LMenu = 164,
-        //
-        // Summary:
-        //     The right ALT key.
-        RMenu = 165,
-        //
-        // Summary:
-        //     The browser back key (Windows 2000 or later).
-        BrowserBack = 166,
-        //
-        // Summary:
-        //     The browser forward key (Windows 2000 or later).
-        BrowserForward = 167,
-        //
-        // Summary:
-        //     The browser refresh key (Windows 2000 or later).
-        BrowserRefresh = 168,
-        //
-        // Summary:
-        //     The browser stop key (Windows 2000 or later).
-        BrowserStop = 169,
-        //
-        // Summary:
-        //     The browser search key (Windows 2000 or later).
-        BrowserSearch = 170,
-        //
-        // Summary:
-        //     The browser favorites key (Windows 2000 or later).
-        BrowserFavorites = 171,
-        //
-        // Summary:
-        //     The browser home key (Windows 2000 or later).
-        BrowserHome = 172,
-        //
-        // Summary:
-        //     The volume mute key (Windows 2000 or later).
-        VolumeMute = 173,
-        //
-        // Summary:
-        //     The volume down key (Windows 2000 or later).
-        VolumeDown = 174,
-        //
-        // Summary:
-        //     The volume up key (Windows 2000 or later).
-        VolumeUp = 175,
-        //
-        // Summary:
-        //     The media next track key (Windows 2000 or later).
-        MediaNextTrack = 176,
-        //
-        // Summary:
-        //     The media previous track key (Windows 2000 or later).
-        MediaPreviousTrack = 177,
-        //
-        // Summary:
-        //     The media Stop key (Windows 2000 or later).
-        MediaStop = 178,
-        //
-        // Summary:
-        //     The media play pause key (Windows 2000 or later).
-        MediaPlayPause = 179,
-        //
-        // Summary:
-        //     The launch mail key (Windows 2000 or later).
-        LaunchMail = 180,
-        //
-        // Summary:
-        //     The select media key (Windows 2000 or later).
-        SelectMedia = 181,
-        //
-        // Summary:
-        //     The start application one key (Windows 2000 or later).
-        LaunchApplication1 = 182,
-        //
-        // Summary:
-        //     The start application two key (Windows 2000 or later).
-        LaunchApplication2 = 183,
-        //
-        // Summary:
-        //     The OEM Semicolon key on a US standard keyboard (Windows 2000 or later).
-        OemSemicolon = 186,
-        //
-        // Summary:
-        //     The OEM 1 key.
-        Oem1 = 186,
-        //
-        // Summary:
-        //     The OEM plus key on any country/region keyboard (Windows 2000 or later).
-        Oemplus = 187,
-        //
-        // Summary:
-        //     The OEM comma key on any country/region keyboard (Windows 2000 or later).
-        Oemcomma = 188,
-        //
-        // Summary:
-        //     The OEM minus key on any country/region keyboard (Windows 2000 or later).
-        OemMinus = 189,
-        //
-        // Summary:
-        //     The OEM period key on any country/region keyboard (Windows 2000 or later).
-        OemPeriod = 190,
-        //
-        // Summary:
-        //     The OEM question mark key on a US standard keyboard (Windows 2000 or later).
-        OemQuestion = 191,
-        //
-        // Summary:
-        //     The OEM 2 key.
-        Oem2 = 191,
-        //
-        // Summary:
-        //     The OEM tilde key on a US standard keyboard (Windows 2000 or later).
-        Oemtilde = 192,
-        //
-        // Summary:
-        //     The OEM 3 key.
-        Oem3 = 192,
-        //
-        // Summary:
-        //     The OEM open bracket key on a US standard keyboard (Windows 2000 or later).
-        OemOpenBrackets = 219,
-        //
-        // Summary:
-        //     The OEM 4 key.
-        Oem4 = 219,
-        //
-        // Summary:
-        //     The OEM pipe key on a US standard keyboard (Windows 2000 or later).
-        OemPipe = 220,
-        //
-        // Summary:
-        //     The OEM 5 key.
-        Oem5 = 220,
-        //
-        // Summary:
-        //     The OEM close bracket key on a US standard keyboard (Windows 2000 or later).
-        OemCloseBrackets = 221,
-        //
-        // Summary:
-        //     The OEM 6 key.
-        Oem6 = 221,
-        //
-        // Summary:
-        //     The OEM singled/double quote key on a US standard keyboard (Windows 2000 or later).
-        OemQuotes = 222,
-        //
-        // Summary:
-        //     The OEM 7 key.
-        Oem7 = 222,
-        //
-        // Summary:
-        //     The OEM 8 key.
-        Oem8 = 223,
-        //
-        // Summary:
-        //     The OEM angle bracket or backslash key on the RT 102 key keyboard (Windows 2000
-        //     or later).
-        OemBackslash = 226,
-        //
-        // Summary:
-        //     The OEM 102 key.
-        Oem102 = 226,
-        //
-        // Summary:
-        //     The PROCESS KEY key.
-        ProcessKey = 229,
-        //
-        // Summary:
-        //     Used to pass Unicode characters as if they were keystrokes. The Packet key value
-        //     is the low word of a 32-bit virtual-key value used for non-keyboard input methods.
-        Packet = 231,
-        //
-        // Summary:
-        //     The ATTN key.
-        Attn = 246,
-        //
-        // Summary:
-        //     The CRSEL key.
-        Crsel = 247,
-        //
-        // Summary:
-        //     The EXSEL key.
-        Exsel = 248,
-        //
-        // Summary:
-        //     The ERASE EOF key.
-        EraseEof = 249,
-        //
-        // Summary:
-        //     The PLAY key.
-        Play = 250,
-        //
-        // Summary:
-        //     The ZOOM key.
-        Zoom = 251,
-        //
-        // Summary:
-        //     A constant reserved for future use.
-        NoName = 252,
-        //
-        // Summary:
-        //     The PA1 key.
-        Pa1 = 253,
-        //
-        // Summary:
-        //     The CLEAR key.
-        OemClear = 254,
-        //
-        // Summary:
-        //     The bitmask to extract a key code from a key value.
-        KeyCode = 65535,
-        //
-        // Summary:
-        //     The SHIFT modifier key.
-        Shift = 65536,
-        //
-        // Summary:
-        //     The CTRL modifier key.
-        Control = 131072,
-        //
-        // Summary:
-        //     The ALT modifier key.
-        Alt = 262144
-    }
-
     public delegate void IndexChangedEvent(UIMenu sender, int newIndex);
     public delegate void ListChangedEvent(UIMenu sender, UIMenuListItem listItem, int newIndex);
     public delegate void SliderChangedEvent(UIMenu sender, UIMenuSliderItem listItem, int newIndex);
@@ -1244,7 +462,7 @@ namespace ScaleformUI.Menu
             foreach (UIMenuItem it in MenuItems) it.Selected = false;
             if (Visible)
             {
-                SendItems();
+                BuildUpMenuAsync(true);
                 int index = CurrentSelection;
                 isBuilding = false;
                 CurrentSelection = keepIndex ? index : 0;
@@ -1629,6 +847,8 @@ namespace ScaleformUI.Menu
         internal int context = 0;
         internal int unused = 0;
         internal bool success;
+        bool wasPressedInPanel;
+        bool wasPressedInItem;
         bool cursorPressed;
         bool cursorPressedItem;
         private ItemFont descriptionFont = ScaleformFonts.CHALET_LONDON_NINETEENSIXTY;
@@ -1670,6 +890,17 @@ namespace ScaleformUI.Menu
                     case 5: // on click
                         switch (context)
                         {
+                            case -1:
+                                switch (itemId)
+                                {
+                                    case 2:
+                                        GoUp();
+                                        break;
+                                    case 3:
+                                        GoDown();
+                                        break;
+                                }
+                                break;
                             case 0:
                                 {
                                     UIMenuItem item = MenuItems[itemId];
@@ -1763,7 +994,10 @@ namespace ScaleformUI.Menu
                                     if (item.Selected)
                                     {
                                         if (item._itemId == 1 || item._itemId == 3 || item._itemId == 4)
+                                        {
                                             cursorPressedItem = true;
+                                            wasPressedInItem = true;
+                                        }
                                         return;
                                     }
                                     CurrentSelection = itemId;
@@ -1831,10 +1065,9 @@ namespace ScaleformUI.Menu
                                 }
                                 break;
                             case 11: // panels (11 => context 1, panel_type 1) // PercentagePanel
-                                cursorPressed = true;
-                                break;
                             case 12: // panels (12 => context 1, panel_type 2) // GridPanel
                                 cursorPressed = true;
+                                wasPressedInPanel = true;
                                 break;
                             case 20: // side panel
                                 {
@@ -1853,11 +1086,15 @@ namespace ScaleformUI.Menu
                         break;
                     case 6: // on click released
                         cursorPressed = false;
+                        wasPressedInPanel = false;
                         cursorPressedItem = false;
+                        wasPressedInItem = false;
                         break;
                     case 7: // on click released ouside
                         cursorPressed = false;
+                        wasPressedInPanel = false;
                         cursorPressedItem = false;
+                        wasPressedInItem = false;
                         SetMouseCursorSprite(1);
                         if (mouseReset)
                             mouseReset = false;
@@ -1920,7 +1157,9 @@ namespace ScaleformUI.Menu
                         cursorPressedItem = false;
                         break;
                     case 1: // dragged inside
-                        cursorPressed = true;
+                        if(wasPressedInPanel)
+                            cursorPressed = true;
+                        if(wasPressedInItem)
                         cursorPressedItem = true;
                         break;
                 }
@@ -2459,9 +1698,6 @@ namespace ScaleformUI.Menu
                     _unfilteredMenuItems.Clear();
                     AddTextEntry("UIMenu_Current_Description", "");
                 }
-                Main.scaleformUI.CallFunction("SET_VISIBLE", _visible, CurrentSelection, topEdge);
-                SendPanelsToItemScaleform(CurrentSelection);
-                SendSidePanelToScaleform(CurrentSelection);
                 if (!value) return;
                 if (!ResetCursorOnOpen) return;
                 SetCursorLocation(0.5f, 0.5f);
@@ -2478,11 +1714,16 @@ namespace ScaleformUI.Menu
                 SetMenuData(skipViewInitialization);
                 SetWindows();
             }
+
             if (!Visible) return;
             SendItems();
 
             //Pagination.ScaleformIndex = Pagination.GetScaleformIndex(CurrentSelection);
-
+            Main.scaleformUI.CallFunction("SET_VISIBLE", _visible, CurrentSelection, topEdge);
+            if (CurrentItem is UIMenuSeparatorItem sp && sp.Jumpable)
+                GoDown();
+            SendPanelsToItemScaleform(CurrentSelection);
+            SendSidePanelToScaleform(CurrentSelection);
             Main.scaleformUI.CallFunction("ENABLE_MOUSE", MouseControlsEnabled);
             isBuilding = false;
         }
@@ -2597,7 +1838,8 @@ namespace ScaleformUI.Menu
                     Main.scaleformUI.CallFunction(str, index, 1, (int)cp.PanelSide, (int)cp._titleType, cp.Title, cp.TitleColor);
                     break;
             }
-            Main.scaleformUI.CallFunction("SHOW_SIDE_PANEL");
+            if (!update)
+                Main.scaleformUI.CallFunction("SHOW_SIDE_PANEL");
         }
 
         internal void SendPanelsToItemScaleform(int i, bool update = false)
@@ -2639,7 +1881,8 @@ namespace ScaleformUI.Menu
                         break;
                 }
             }
-            Main.scaleformUI.CallFunction("SHOW_PANELS");
+            if (!update) 
+                Main.scaleformUI.CallFunction("SHOW_PANELS");
         }
 
         internal void SendItemToScaleform(int i, bool update = false, bool newItem = false)

--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -2833,12 +2833,6 @@ namespace ScaleformUI.Menu
                 glarePosition = new Vector2(screenCoords.X - 1 + startPoint, screenCoords.Y + 0.45f + safezone);
             }
             glareSize = new SizeF(ScreenTools.GetWideScreen() ? 1.35f : 1f, 1f);
-
-
-            Notifications.DrawText(0.35f, 0.7f, "safezone: " + safezone);
-            Notifications.DrawText(0.35f, 0.725f, "GetSafeZoneSize: " + GetSafeZoneSize());
-            Notifications.DrawText(0.35f, 0.75f, "screenCoords: " + screenCoords);
-            Notifications.DrawText(0.35f, 0.775f, "glarePosition: " + glarePosition);
             SetMenuData(true);
         }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -2290,15 +2290,15 @@ namespace ScaleformUI.Menu
             OnMenuClose?.Invoke(menu);
         }
 
-        protected virtual void ColorPanelChange(UIMenuItem item, UIMenuColorPanel panel, int index)
+        internal virtual void ColorPanelChange(UIMenuItem item, UIMenuColorPanel panel, int index)
         {
             OnColorPanelChange?.Invoke(item, panel, index);
         }
-        protected virtual void PercentagePanelChange(UIMenuItem item, UIMenuPercentagePanel panel, float index)
+        internal virtual void PercentagePanelChange(UIMenuItem item, UIMenuPercentagePanel panel, float index)
         {
             OnPercentagePanelChange?.Invoke(item, panel, index);
         }
-        protected virtual void GridPanelChange(UIMenuItem item, UIMenuGridPanel panel, PointF index)
+        internal virtual void GridPanelChange(UIMenuItem item, UIMenuGridPanel panel, PointF index)
         {
             OnGridPanelChange?.Invoke(item, panel, index);
         }

--- a/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/UIMenu.cs
@@ -2836,9 +2836,6 @@ namespace ScaleformUI.Menu
             SetMenuData(true);
         }
 
-
-
-
         /// <summary>
         /// Returns the current selected item's index.
         /// Change the current selected item to index. Use this after you add or remove items dynamically.

--- a/ScaleformUI_Csharp/Menus/UIMenu/Windows/UIMenuDetailsWindow.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Windows/UIMenuDetailsWindow.cs
@@ -18,7 +18,10 @@ namespace ScaleformUI.Menu
             DetailMid = mid;
             DetailBottom = bot;
             StatWheelEnabled = false;
-            DetailLeft = leftDetail ?? new();
+            DetailLeft = leftDetail ?? new()
+            {
+                Txd = "statWheel"
+            };
         }
 
         public UIMenuDetailsWindow(string top, string mid, string bot, bool statWheelEnabled, List<UIDetailStat> details)
@@ -40,15 +43,11 @@ namespace ScaleformUI.Menu
             DetailTop = top;
             DetailMid = mid;
             DetailBottom = bot;
-            DetailLeft = leftDetail ?? new();
-            if (ParentMenu is not null)
+            DetailLeft = leftDetail ?? new()
             {
-                int wid = ParentMenu.Windows.IndexOf(this);
-                if (!StatWheelEnabled)
-                    Main.scaleformUI.CallFunction("UPDATE_DETAILS_WINDOW_VALUES", wid, DetailBottom, DetailMid, DetailTop, DetailLeft.Txd, DetailLeft.Txn, DetailLeft.Pos.X, DetailLeft.Pos.Y, DetailLeft.Size.Width, DetailLeft.Size.Height);
-                else
-                    Main.scaleformUI.CallFunction("UPDATE_DETAILS_WINDOW_VALUES", wid, DetailBottom, DetailMid, DetailTop, "statWheel");
-            }
+                Txd = "statWheel"
+            };
+            ParentMenu?.SetWindows(true);
         }
 
         public void AddStatsListToWheel(List<UIDetailStat> stats)
@@ -56,14 +55,7 @@ namespace ScaleformUI.Menu
             if (StatWheelEnabled)
             {
                 DetailStats = stats;
-                if (ParentMenu is not null)
-                {
-                    int wid = ParentMenu.Windows.IndexOf(this);
-                    foreach (UIDetailStat value in stats)
-                    {
-                        Main.scaleformUI.CallFunction("ADD_STATS_DETAILS_WINDOW_STATWHEEL", wid, value.Percentage, value.HudColor);
-                    }
-                }
+                ParentMenu?.SetWindows(true);
             }
         }
 
@@ -72,11 +64,7 @@ namespace ScaleformUI.Menu
             if (StatWheelEnabled)
             {
                 DetailStats.Add(stat);
-                if (ParentMenu is not null)
-                {
-                    int wid = ParentMenu.Windows.IndexOf(this);
-                    Main.scaleformUI.CallFunction("ADD_STATS_DETAILS_WINDOW_STATWHEEL", wid, stat.Percentage, stat.HudColor);
-                }
+                ParentMenu?.SetWindows(true);
             }
         }
 
@@ -93,20 +81,13 @@ namespace ScaleformUI.Menu
                     throw new Exception("You cannot add items using this function");
                 }
                 DetailStats = stats;
-                if (ParentMenu is not null)
-                {
-                    int wid = ParentMenu.Windows.IndexOf(this);
-                    foreach (UIDetailStat value in DetailStats)
-                    {
-                        Main.scaleformUI.CallFunction("UPDATE_STATS_DETAILS_WINDOW_STATWHEEL", wid, DetailStats.IndexOf(value), value.Percentage, value.HudColor);
-                    }
-                }
+                ParentMenu?.SetWindows(true);
             }
         }
         public void RemoveStatToWheel(UIDetailStat stat)
         {
             UIDetailStat s = DetailStats.FirstOrDefault(x => x.Percentage == stat.Percentage && x.HudColor == stat.HudColor);
-            if (s is not null)
+            if (s != null)
             {
                 RemoveStatToWheel(DetailStats.IndexOf(s));
             }
@@ -115,11 +96,7 @@ namespace ScaleformUI.Menu
         {
             if (id < 0 || id >= DetailStats.Count) return;
             DetailStats.RemoveAt(id);
-            if (ParentMenu is not null)
-            {
-                int wid = ParentMenu.Windows.IndexOf(this);
-                Main.scaleformUI.CallFunction("REMOVE_STATS_DETAILS_WINDOW_STATWHEEL", wid, id);
-            }
+            ParentMenu?.SetWindows(true);
         }
     }
 

--- a/ScaleformUI_Csharp/Menus/UIMenu/Windows/UIMenuHeritageWindow.cs
+++ b/ScaleformUI_Csharp/Menus/UIMenu/Windows/UIMenuHeritageWindow.cs
@@ -29,7 +29,7 @@ namespace ScaleformUI.Menu
                 await BaseScript.Delay(0);
                 API.RequestStreamedTextureDict("char_creator_portraits", true);
             }
-            Main.scaleformUI.CallFunction("UPDATE_HERITAGE_WINDOW", wid, Mom, Dad);
+            ParentMenu?.SetWindows(true);
             API.SetStreamedTextureDictAsNoLongerNeeded("char_creator_portraits");
         }
     }

--- a/ScaleformUI_Csharp/Menus/UIRadioMenu/UIRadioMenu.cs
+++ b/ScaleformUI_Csharp/Menus/UIRadioMenu/UIRadioMenu.cs
@@ -121,7 +121,7 @@ namespace ScaleformUI.Radio
             Stations.Add(station);
         }
 
-        internal override async void ProcessControl(Keys key = Keys.None)
+        internal override async void ProcessControl()
         {
             Controls.Toggle(false);
             // block camera movements

--- a/ScaleformUI_Lua/example.lua
+++ b/ScaleformUI_Lua/example.lua
@@ -11,14 +11,12 @@ function CreateMenu()
 	local exampleMenu = UIMenu.New("ScaleformUI", "ScaleformUI SHOWCASE", 50, 50, true, "scaleformui", "menubanner", true)
 	exampleMenu:MaxItemsOnScreen(7)
 	exampleMenu:BuildingAnimation(MenuBuildingAnimation.LEFT_RIGHT)
-	exampleMenu:AnimationType(MenuAnimationType.CUBIC_INOUT)
-	exampleMenu:ScrollingType(MenuScrollingType.CLASSIC)
 	exampleMenu:CounterColor(SColor.HUD_Yellow)
 
 	local currentTransition = "TRANSITION_OUT"
 	local bigMessageItem = UIMenuItem.New("Big Message Example", "Big Message Examples")
 	exampleMenu:AddItem(bigMessageItem)
-	local bigMessageExampleMenu = UIMenu.New("Big Message Example", "Big Message Examples", 50, 50, true, nil, nil, true)
+	local bigMessageExampleMenu = UIMenu.New("Big Message Example", "Big Message Examples", 50, 50, true, "", "", true)
 
 	local uiItemTransitionList = UIMenuListItem.New("Transition",
 		{ "TRANSITION_OUT", "TRANSITION_UP", "TRANSITION_DOWN" },
@@ -26,8 +24,8 @@ function CreateMenu()
 		"Transition type for the big message")
 	bigMessageExampleMenu:AddItem(uiItemTransitionList)
 
-	local uiItemBigMessageManualDispose = UIMenuCheckboxItem.New("Manual Dispose", false,
-		"Manually dispose the big message")e
+	local uiItemBigMessageManualDispose = UIMenuCheckboxItem.New("Manual Dispose", false, 1,
+		"Manually dispose the big message")
 	bigMessageExampleMenu:AddItem(uiItemBigMessageManualDispose)
 
 	local uiItemMessageType = UIMenuListItem.New("Message Type",

--- a/ScaleformUI_Lua/src/Elements/ItemFont.lua
+++ b/ScaleformUI_Lua/src/Elements/ItemFont.lua
@@ -1,6 +1,9 @@
 ItemFont = setmetatable({}, ItemFont)
 
 ---@class ItemFont
+---@field public FontName string
+---@field public FontID number
+
 
 ---@comment Creates a new ItemFont
 ---@param fontName string

--- a/ScaleformUI_Lua/src/Menus/MenuHandler.lua
+++ b/ScaleformUI_Lua/src/Menus/MenuHandler.lua
@@ -46,8 +46,6 @@ function MenuHandler:SwitchTo(currentMenu, newMenu, newMenuCurrentSelection, inh
             newMenu.Glare = currentMenu.Glare
             newMenu.AlternativeTitle = currentMenu.AlternativeTitle
             newMenu:MaxItemsOnScreen(currentMenu:MaxItemsOnScreen())
-            newMenu:ScrollingType(currentMenu:ScrollingType())
-            newMenu:SetMenuAnimations(currentMenu:AnimationEnabled(), currentMenu:Enabled3DAnimations(), currentMenu:AnimationType(), currentMenu:BuildingAnimation(), currentMenu.fadingTime)
             newMenu:MouseSettings(currentMenu:MouseControlsEnabled(), currentMenu:MouseEdgeEnabled(), currentMenu:MouseWheelControlEnabled(), currentMenu.Settings.ResetCursorOnOpen, currentMenu.leftClickEnabled)
             newMenu:SubtitleColor(currentMenu:SubtitleColor())
             --[[
@@ -57,14 +55,8 @@ function MenuHandler:SwitchTo(currentMenu, newMenu, newMenuCurrentSelection, inh
         end
     end
     newMenu:CurrentSelection(newMenuCurrentSelection)
-    if (current == "UIMenu") then
-        currentMenu:FadeOutMenu()
-    end
     currentMenu:Visible(false)
     newMenu:Visible(true)
-    if (new == "UIMenu") then
-        newMenu:FadeInMenu()
-    end
     BreadcrumbsHandler:Forward(newMenu, data)
     BreadcrumbsHandler.SwitchInProgress = false
 end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuDynamicListItem.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuDynamicListItem.lua
@@ -18,12 +18,9 @@ UIMenuDynamicListItem.__call = function() return "UIMenuItem", "UIMenuDynamicLis
 ---@param callback function
 ---@param color SColor
 ---@param highlightColor SColor
----@param textColor SColor
----@param highlightedTextColor SColor
-function UIMenuDynamicListItem.New(Text, Description, StartingItem, callback, color, highlightColor, textColor,
-                                   highlightedTextColor)
+function UIMenuDynamicListItem.New(Text, Description, StartingItem, callback, color, highlightColor)
     local _UIMenuDynamicListItem = {
-        Base = UIMenuItem.New(Text or "", Description or "", color or SColor.HUD_Panel_light, highlightColor or SColor.HUD_White, textColor or SColor.HUD_White, highlightedTextColor or SColor.HUD_Black),
+        Base = UIMenuItem.New(Text or "", Description or "", color or SColor.HUD_Panel_light, highlightColor or SColor.HUD_White),
         Panels = {},
         SidePanel = nil,
         _currentItem = StartingItem,
@@ -37,235 +34,103 @@ end
 
 function UIMenuDynamicListItem:ItemData(data)
     if data == nil then
-        return self.Base._itemData
+        return self.Base:ItemData(data)
     else
-        self.Base._itemData = data
+        self.Base:ItemData()
     end
 end
 
 -- not supported on Lobby and Pause menu yet
-function UIMenuDynamicListItem:LabelFont(fontTable)
-    if fontTable == nil then
+function UIMenuDynamicListItem:LabelFont(itemFont)
+    if itemFont == nil then
         return self.Base:LabelFont()
-    else
-        self.Base:LabelFont(fontTable)
     end
+    self.Base:LabelFont(itemFont, self)
 end
 
 -- not supported on Lobby and Pause menu yet
-function UIMenuDynamicListItem:RightLabelFont(fontTable)
-    if fontTable == nil then
+function UIMenuDynamicListItem:RightLabelFont(itemFont)
+    if itemFont == nil then
         return self.Base:RightLabelFont()
-    else
-        self.Base:RightLabelFont(fontTable)
     end
+    self.Base:RightLabelFont(itemFont, self)
 end
 
-function UIMenuDynamicListItem:CurrentListItem(item)
-    if item == nil then
-        return tostring(self._currentItem)
-    else
-        self._currentItem = item
-        local str = self:createListString()
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_LISTITEM_LIST", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), str, 0)
-        end
-        if self.Base.ParentColumn ~= nil then
-            local pSubT = self.Base.ParentColumn.Parent()
-            if pSubT == "LobbyMenu" then
-                ScaleformUI.Scaleforms._pauseMenu._lobby:CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), str, self._Index - 1)
-            elseif pSubT == "PauseMenu" and self.Base.ParentColumn.ParentTab.Visible then
-                ScaleformUI.Scaleforms._pauseMenu._pause:CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), str, self._Index - 1)
-            end
-        end
+---Set the Parent Menu of the Item
+---@param menu UIMenu
+---@return UIMenu? -- returns the parent menu if no menu is passed, if a menu is passed it returns the menu if it was set successfully
+function UIMenuDynamicListItem:SetParentMenu(menu)
+    if menu == nil then
+        return self.Base:SetParentMenu()
     end
+    self.Base:SetParentMenu(menu)
 end
 
----SetParentMenu
----@param Menu table
-function UIMenuDynamicListItem:SetParentMenu(Menu)
-    if Menu ~= nil and Menu() == "UIMenu" then
-        self.Base.ParentMenu = Menu
-    else
-        return self.Base.ParentMenu
-    end
-end
-
-function UIMenuDynamicListItem:AddSidePanel(sidePanel)
-    if sidePanel() == "UIMissionDetailsPanel" then
-        sidePanel:SetParentItem(self)
-        self.SidePanel = sidePanel
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), 0,
-                sidePanel.PanelSide, sidePanel.TitleType,
-                sidePanel.Title,
-                sidePanel.TitleColor, sidePanel.TextureDict, sidePanel.TextureName)
-        end
-    elseif sidePanel() == "UIVehicleColorPickerPanel" then
-        sidePanel:SetParentItem(self)
-        self.SidePanel = sidePanel
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM",
-            IndexOf(self.Base.ParentMenu.Items, self), 1, sidePanel.PanelSide, sidePanel.TitleType, sidePanel.Title,
-                sidePanel.TitleColor)
-        end
-    end
-end
-
----Selected
----@param bool boolean
 function UIMenuDynamicListItem:Selected(bool)
-    if bool ~= nil then
-        self.Base:Selected(ToBool(bool), self)
-        local str = self:createListString()
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_LISTITEM_LIST", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), str, 0)
-        end
-        if self.Base.ParentColumn ~= nil then
-            local pSubT = self.Base.ParentColumn.Parent()
-            if pSubT == "LobbyMenu" then
-                ScaleformUI.Scaleforms._pauseMenu._lobby:CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), str, self._Index - 1)
-            elseif pSubT == "PauseMenu" and self.Base.ParentColumn.ParentTab.Visible then
-                ScaleformUI.Scaleforms._pauseMenu._pause:CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), str, self._Index - 1)
-            end
-        end
-    else
-        return self.Base._Selected
+    if bool == nil then
+        return self.Base:Selected()
     end
+    self.Base:Selected(bool, self)
 end
 
----Hovered
----@param bool boolean
 function UIMenuDynamicListItem:Hovered(bool)
-    if bool ~= nil then
-        self.Base._Hovered = ToBool(bool)
-    else
-        return self.Base._Hovered
+    if bool == nil then
+        return self.Base:Hovered()
     end
+    self.Base:Hovered(bool)
 end
 
----Enabled
----@param bool boolean
 function UIMenuDynamicListItem:Enabled(bool)
-    if bool ~= nil then
-        self.Base:Enabled(bool, self)
-        local str = self:createListString()
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_LISTITEM_LIST", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), str, 0)
-        end
-        if self.Base.ParentColumn ~= nil then
-            local pSubT = self.Base.ParentColumn.Parent()
-            if pSubT == "LobbyMenu" then
-                ScaleformUI.Scaleforms._pauseMenu._lobby:CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), str, self._Index - 1)
-            elseif pSubT == "PauseMenu" and self.Base.ParentColumn.ParentTab.Visible then
-                ScaleformUI.Scaleforms._pauseMenu._pause:CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), str, self._Index - 1)
-            end
-        end
-    else
-        return self.Base._Enabled
+    if bool == nil then
+        return self.Base:Enabled()
     end
+    self.Base:Hovered(bool, self)
 end
 
----Description
----@param str string
 function UIMenuDynamicListItem:Description(str)
-    if tostring(str) and str ~= nil then
-        self.Base:Description(tostring(str), self)
-    else
-        return self.Base._Description
+    if str == nil then
+        return self.Base:Description()
     end
-end
-
-function UIMenuDynamicListItem:BlinkDescription(bool)
-    if bool ~= nil then
-        self.Base:BlinkDescription(bool, self)
-    else
-        return self.Base:BlinkDescription()
-    end
-end
-
----Text
----@param Text string
-function UIMenuDynamicListItem:Label(Text)
-    if tostring(Text) and Text ~= nil then
-        self.Base:Label(tostring(Text), self)
-    else
-        return self.Base:Label()
-    end
+    self.Base:Description(str, self)
 end
 
 function UIMenuDynamicListItem:MainColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._mainColor = color
-        if (self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible()) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._mainColor
+    if color == nil then
+        return self.Base:MainColor()
     end
-end
-
-function UIMenuDynamicListItem:TextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._textColor = color
-        if (self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible()) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._textColor
-    end
+    self.Base:MainColor(color, self)
 end
 
 function UIMenuDynamicListItem:HighlightColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightColor = color
-        if (self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible()) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightColor
+    if color == nil then
+        return self.Base:HighlightColor()
     end
+    self.Base:HighlightColor(color, self)
 end
 
-function UIMenuDynamicListItem:HighlightedTextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightedTextColor = color
-        if (self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible()) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightedTextColor
+function UIMenuDynamicListItem:Label(Text)
+    if Text == nil then
+        return self.Base:Label()
     end
+    self.Base:Label(Text, self)
 end
 
----LeftBadge
+function UIMenuDynamicListItem:BlinkDescription(bool)
+    if bool == nil then
+        return self.Base:BlinkDescription()
+    end
+    self.Base:BlinkDescription(bool, self)
+end
+
 function UIMenuDynamicListItem:LeftBadge(Badge)
-    if tonumber(Badge) then
-        self.Base:LeftBadge(Badge, self)
-    else
+    if Badge == nil then
         return self.Base:LeftBadge()
     end
+    self.Base:LeftBadge(Badge, self)
 end
 
 function UIMenuDynamicListItem:CustomLeftBadge(txd,txn)
-    if txd ~= nil and txd ~= "" and txn ~= nil and txn ~= "" then
-        self.Base:CustomLeftBadge(txd,txn, self)
-    else
-        return self.Base:LeftBadge()
-    end
+    self.Base:CustomLeftBadge(txd,txn, self)
 end
 
 ---RightBadge
@@ -324,6 +189,28 @@ function UIMenuDynamicListItem:FindPanelItem()
     return nil
 end
 
+function UIMenuDynamicListItem:CurrentListItem(item, _item)
+    if item == nil then
+        return tostring(self._currentItem)
+    else
+        self._currentItem = item
+        if _item == nil then _item = self end
+        local str = self:createListString()
+        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() then
+            local it = IndexOf(self.Base.ParentMenu.Items, _item)
+            self.Base.ParentMenu:SendItemToScaleform(it, true)
+        end
+        if self.Base.ParentColumn ~= nil then
+            local pSubT = self.Base.ParentColumn.Parent()
+            if pSubT == "LobbyMenu" then
+                ScaleformUI.Scaleforms._pauseMenu._lobby:CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), str, self._Index - 1)
+            elseif pSubT == "PauseMenu" and self.Base.ParentColumn.ParentTab.Visible then
+                ScaleformUI.Scaleforms._pauseMenu._pause:CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), str, self._Index - 1)
+            end
+        end
+    end
+end
+
 function UIMenuDynamicListItem:createListString()
     local list = {}
     local value = self._currentItem
@@ -331,7 +218,7 @@ function UIMenuDynamicListItem:createListString()
         value = tostring(v)
     end
     if not self:Enabled() then
-        value.ReplaceRstarColorsWith("~c~")
+        value = ReplaceRstarColorsWith(value, "~c~")
     else
         if not value:StartsWith("~") then
             value = "~s~" .. value

--- a/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuDynamicListItem.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuDynamicListItem.lua
@@ -195,12 +195,12 @@ function UIMenuDynamicListItem:CurrentListItem(item, _item)
     else
         self._currentItem = item
         if _item == nil then _item = self end
-        local str = self:createListString()
         if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() then
             local it = IndexOf(self.Base.ParentMenu.Items, _item)
             self.Base.ParentMenu:SendItemToScaleform(it, true)
         end
         if self.Base.ParentColumn ~= nil then
+            local str = self:createListString()
             local pSubT = self.Base.ParentColumn.Parent()
             if pSubT == "LobbyMenu" then
                 ScaleformUI.Scaleforms._pauseMenu._lobby:CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), str, self._Index - 1)

--- a/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuListItem.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuListItem.lua
@@ -11,11 +11,11 @@ UIMenuListItem.__call = function() return "UIMenuItem", "UIMenuListItem" end
 ---@param Items table
 ---@param Index number
 ---@param Description string
-function UIMenuListItem.New(Text, Items, Index, Description, color, highlightColor, textColor, highlightedTextColor)
+function UIMenuListItem.New(Text, Items, Index, Description, color, highlightColor)
     if type(Items) ~= "table" then Items = {} end
     if Index == 0 then Index = 1 end
     local _UIMenuListItem = {
-        Base = UIMenuItem.New(Text or "", Description or "", color or SColor.HUD_Panel_light, highlightColor or SColor.HUD_White, textColor or SColor.HUD_White, highlightedTextColor or SColor.HUD_Black),
+        Base = UIMenuItem.New(Text or "", Description or "", color or SColor.HUD_Panel_light, highlightColor or SColor.HUD_White),
         Items = Items,
         _Index = tonumber(Index) or 1,
         Panels = {},
@@ -31,265 +31,104 @@ end
 
 function UIMenuListItem:ItemData(data)
     if data == nil then
-        return self.Base._itemData
+        return self.Base:ItemData(data)
     else
-        self.Base._itemData = data
-    end
-end
-
----SetParentMenu
----@param Menu table
-function UIMenuListItem:SetParentMenu(Menu)
-    if Menu ~= nil and Menu() == "UIMenu" then
-        self.Base.ParentMenu = Menu
-    else
-        return self.Base.ParentMenu
-    end
-end
-
-function UIMenuListItem:LabelFont(fontTable)
-    if fontTable == nil then
-        return self.Base:LabelFont()
-    else
-        self.Base:LabelFont(fontTable)
+        self.Base:ItemData()
     end
 end
 
 -- not supported on Lobby and Pause menu yet
-function UIMenuListItem:RightLabelFont(fontTable)
-    if fontTable == nil then
+function UIMenuListItem:LabelFont(itemFont)
+    if itemFont == nil then
+        return self.Base:LabelFont()
+    end
+    self.Base:LabelFont(itemFont, self)
+end
+
+-- not supported on Lobby and Pause menu yet
+function UIMenuListItem:RightLabelFont(itemFont)
+    if itemFont == nil then
         return self.Base:RightLabelFont()
-    else
-        self.Base:RightLabelFont(fontTable)
     end
+    self.Base:RightLabelFont(itemFont, self)
 end
 
-function UIMenuListItem:AddSidePanel(sidePanel)
-    if sidePanel() == "UIMissionDetailsPanel" then
-        sidePanel:SetParentItem(self)
-        self.SidePanel = sidePanel
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), 0,
-                sidePanel.PanelSide, sidePanel.TitleType,
-                sidePanel.Title,
-                sidePanel.TitleColor, sidePanel.TextureDict, sidePanel.TextureName)
-        end
-    elseif sidePanel() == "UIVehicleColorPickerPanel" then
-        sidePanel:SetParentItem(self)
-        self.SidePanel = sidePanel
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM",
-                IndexOf(self.Base.ParentMenu.Items, self), 1, sidePanel.PanelSide, sidePanel.TitleType, sidePanel.Title,
-                sidePanel.TitleColor)
-        end
+---Set the Parent Menu of the Item
+---@param menu UIMenu
+---@return UIMenu? -- returns the parent menu if no menu is passed, if a menu is passed it returns the menu if it was set successfully
+function UIMenuListItem:SetParentMenu(menu)
+    if menu == nil then
+        return self.Base:SetParentMenu()
     end
+    self.Base:SetParentMenu(menu)
 end
 
----Selected
----@param bool? boolean
 function UIMenuListItem:Selected(bool)
-    if bool ~= nil then
-        self.Base:Selected(ToBool(bool), self)
-        local commaSep = self:createListString()
-
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_LISTITEM_LIST",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), commaSep, self._Index - 1)
-        end
-        if self.Base.ParentColumn ~= nil then
-            local pSubT = self.Base.ParentColumn.Parent()
-            if pSubT == "LobbyMenu" then
-                ScaleformUI.Scaleforms._pauseMenu._lobby:CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), commaSep, self._Index - 1)
-            elseif pSubT == "PauseMenu" and self.Base.ParentColumn.ParentTab.Visible then
-                ScaleformUI.Scaleforms._pauseMenu._pause:CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), commaSep, self._Index - 1)
-            end
-        end
-    else
-        return self.Base._Selected
+    if bool == nil then
+        return self.Base:Selected()
     end
+    self.Base:Selected(bool, self)
 end
 
----Hovered
----@param bool boolean
 function UIMenuListItem:Hovered(bool)
-    if bool ~= nil then
-        self.Base._Hovered = ToBool(bool)
-    else
-        return self.Base._Hovered
+    if bool == nil then
+        return self.Base:Hovered()
     end
+    self.Base:Hovered(bool)
 end
 
----Enabled
----@param bool? boolean
 function UIMenuListItem:Enabled(bool)
-    if bool ~= nil then
-        self.Base:Enabled(bool, self)
-        local commaSep = self:createListString()
-
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_LISTITEM_LIST",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), commaSep, self._Index - 1)
-        end
-        if self.Base.ParentColumn ~= nil then
-            local pSubT = self.Base.ParentColumn.Parent()
-            if pSubT == "LobbyMenu" then
-                ScaleformUI.Scaleforms._pauseMenu._lobby:CallFunction("UPDATE_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), commaSep, self._Index - 1)
-            elseif pSubT == "PauseMenu" and self.Base.ParentColumn.ParentTab.Visible then
-                ScaleformUI.Scaleforms._pauseMenu._pause:CallFunction("UPDATE_PLAYERS_TAB_SETTINGS_LISTITEM_LIST", self.Base.ParentColumn.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentColumn.Items, self)), commaSep, self._Index - 1)
-            end
-        end
-    else
-        return self.Base._Enabled
+    if bool == nil then
+        return self.Base:Enabled()
     end
+    self.Base:Hovered(bool, self)
 end
 
----Description
----@param str string
 function UIMenuListItem:Description(str)
-    if tostring(str) and str ~= nil then
-        self.Base:Description(str, self)
-    else
-        return self.Base._Description
+    if str == nil then
+        return self.Base:Description()
     end
-end
-
-function UIMenuListItem:BlinkDescription(bool)
-    if bool ~= nil then
-        self.Base:BlinkDescription(bool, self)
-    else
-        return self.Base:BlinkDescription()
-    end
-end
-
----Text
----@param Text string
-function UIMenuListItem:Label(Text)
-    if tostring(Text) and Text ~= nil then
-        self.Base:Label(tostring(Text), self)
-    else
-        return self.Base:Label()
-    end
+    self.Base:Description(str, self)
 end
 
 function UIMenuListItem:MainColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._mainColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._mainColor
+    if color == nil then
+        return self.Base:MainColor()
     end
-end
-
-function UIMenuListItem:TextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._textColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._textColor
-    end
+    self.Base:MainColor(color, self)
 end
 
 function UIMenuListItem:HighlightColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightColor
+    if color == nil then
+        return self.Base:HighlightColor()
     end
+    self.Base:HighlightColor(color, self)
 end
 
-function UIMenuListItem:HighlightedTextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightedTextColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightedTextColor
+function UIMenuListItem:Label(Text)
+    if Text == nil then
+        return self.Base:Label()
     end
+    self.Base:Label(Text, self)
 end
 
----Index
----@param Index number
-function UIMenuListItem:Index(Index)
-    if tonumber(Index) then
-        if Index > #self.Items then
-            self._Index = 1
-        elseif Index < 1 then
-            self._Index = #self.Items
-        else
-            self._Index = Index
-        end
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_ITEM_VALUE",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self._Index - 1)
-        end
-    else
-        return self._Index
+function UIMenuListItem:BlinkDescription(bool)
+    if bool == nil then
+        return self.Base:BlinkDescription()
     end
+    self.Base:BlinkDescription(bool, self)
 end
 
----ItemToIndex
----@param Item table
-function UIMenuListItem:ItemToIndex(Item)
-    for i = 1, #self.Items do
-        if type(Item) == type(self.Items[i]) and Item == self.Items[i] then
-            return i
-        elseif type(self.Items[i]) == "table" and (type(Item) == type(self.Items[i].Name) or type(Item) == type(self.Items[i].Value)) and (Item == self.Items[i].Name or Item == self.Items[i].Value) then
-            return i
-        end
-    end
-end
-
----IndexToItem
----@param Index number
-function UIMenuListItem:IndexToItem(Index)
-    if tonumber(Index) then
-        if tonumber(Index) == 0 then Index = 1 end
-        if self.Items[tonumber(Index)] then
-            return self.Items[tonumber(Index)]
-        end
-    end
-end
-
----LeftBadge
 function UIMenuListItem:LeftBadge(Badge)
-    if tonumber(Badge) then
-        self.Base:LeftBadge(Badge, self)
-    else
+    if Badge == nil then
         return self.Base:LeftBadge()
     end
+    self.Base:LeftBadge(Badge, self)
 end
 
---- CustomLeftBadge
 function UIMenuListItem:CustomLeftBadge(txd,txn)
-    if txd ~= nil and txd ~= "" and txn ~= nil and txn ~= "" then
-        self.Base:CustomLeftBadge(txd,txn, self)
-    else
-        return self.Base:LeftBadge()
-    end
+    self.Base:CustomLeftBadge(txd,txn, self)
 end
-
 
 ---RightBadge
 function UIMenuListItem:RightBadge()
@@ -347,15 +186,76 @@ function UIMenuListItem:FindPanelItem()
     return nil
 end
 
+
+function UIMenuListItem:AddSidePanel(sidePanel)
+    sidePanel:SetParentItem(self)
+    self.SidePanel = sidePanel
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it)
+    end
+end
+
+function UIMenuListItem:RemoveSidePanel()
+    self.SidePanel = nil
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it)
+    end
+end
+
+---Index
+---@param Index number
+function UIMenuListItem:Index(Index)
+    if tonumber(Index) then
+        if Index > #self.Items then
+            self._Index = 1
+        elseif Index < 1 then
+            self._Index = #self.Items
+        else
+            self._Index = Index
+        end
+        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() then
+            local it = IndexOf(self.Base.ParentMenu.Items, self)
+            self.Base.ParentMenu:SendItemToScaleform(it, true)
+        end
+    else
+        return self._Index
+    end
+end
+
+---ItemToIndex
+---@param Item table
+function UIMenuListItem:ItemToIndex(Item)
+    for i = 1, #self.Items do
+        if type(Item) == type(self.Items[i]) and Item == self.Items[i] then
+            return i
+        elseif type(self.Items[i]) == "table" and (type(Item) == type(self.Items[i].Name) or type(Item) == type(self.Items[i].Value)) and (Item == self.Items[i].Name or Item == self.Items[i].Value) then
+            return i
+        end
+    end
+end
+
+---IndexToItem
+---@param Index number
+function UIMenuListItem:IndexToItem(Index)
+    if tonumber(Index) then
+        if tonumber(Index) == 0 then Index = 1 end
+        if self.Items[tonumber(Index)] then
+            return self.Items[tonumber(Index)]
+        end
+    end
+end
+
 function UIMenuListItem:ChangeList(list)
     if type(list) ~= "table" then return end
     self.Items = {}
     self.Items = list
     local commaSep = self:createListString()
 
-    if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-        ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_LISTITEM_LIST",
-            self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), commaSep, self._Index - 1)
+    if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() then
+        local it = IndexOf(self.Base.ParentMenu.Items, self)
+        self.Base.ParentMenu:SendItemToScaleform(it, true)
     end
     if self.Base.ParentColumn ~= nil then
         local pSubT = self.Base.ParentColumn.Parent()
@@ -368,26 +268,22 @@ function UIMenuListItem:ChangeList(list)
 end
 
 function UIMenuListItem:createListString()
-    local list = {}
-    for k, v in ipairs(self.Items) do
-        local value = v
-        if type(value) ~= "string" then
-            value = tostring(v)
-        end
-        if not self:Enabled() then
-            value.ReplaceRstarColorsWith("~c~")
-        else
-            if not value:StartsWith("~") then
-                value = "~s~" .. value
-            end
-            if self:Selected() then
-                value = value:gsub("~w~", "~l~")
-                value = value:gsub("~s~", "~l~")
-            else
-                value = value:gsub("~l~", "~s~")
-            end
-        end
-        table.insert(list, value)
+    local value = tostring(self.Items[self._Index])
+    if type(value) ~= "string" then
+        value = tostring(v)
     end
-    return table.concat(list, ",")
+    if not self:Enabled() then
+        value = ReplaceRstarColorsWith(value, "~c~")
+    else
+        if not value:StartsWith("~") then
+            value = "~s~" .. value
+        end
+        if self:Selected() then
+            value = value:gsub("~w~", "~l~")
+            value = value:gsub("~s~", "~l~")
+        else
+            value = value:gsub("~l~", "~s~")
+        end
+    end
+    return value
 end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuProgressItem.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuProgressItem.lua
@@ -13,18 +13,16 @@ UIMenuProgressItem.__call = function() return "UIMenuItem", "UIMenuProgressItem"
 ---@param sliderColor SColor
 ---@param color SColor
 ---@param highlightColor SColor
----@param textColor SColor
----@param highlightedTextColor SColor
 ---@param backgroundSliderColor SColor
-function UIMenuProgressItem.New(Text, Max, Index, Description, sliderColor, color, highlightColor, textColor, highlightedTextColor, backgroundSliderColor)
+function UIMenuProgressItem.New(Text, Max, Index, Description, sliderColor, color, highlightColor, backgroundSliderColor)
     local _UIMenuProgressItem = {
-        Base = UIMenuItem.New(Text or "", Description or "", color or SColor.HUD_Panel_light, highlightColor or SColor.HUD_White, textColor or SColor.HUD_White, highlightedTextColor or SColor.HUD_Black),
+        Base = UIMenuItem.New(Text or "", Description or "", color or SColor.HUD_Panel_light, highlightColor or SColor.HUD_White),
         _Max = Max or 100,
         _Multiplier = 5,
         _Index = Index or 0,
         Panels = {},
         SidePanel = nil,
-        SliderColor = sliderColor or SColor.HUD_Freemode,
+        _sliderColor = sliderColor or SColor.HUD_Freemode,
         BackgroundSliderColor = backgroundSliderColor or SColor.HUD_Pause_bg,
         ItemId = 4,
         OnProgressChanged = function(menu, item, newindex)
@@ -38,172 +36,184 @@ end
 
 function UIMenuProgressItem:ItemData(data)
     if data == nil then
-        return self.Base._itemData
+        return self.Base:ItemData(data)
     else
-        self.Base._itemData = data
+        self.Base:ItemData()
     end
 end
 
----SetParentMenu
----@param Menu table
-function UIMenuProgressItem:SetParentMenu(Menu)
-    if Menu() == "UIMenu" then
-        self.Base.ParentMenu = Menu
-    else
-        return self.Base.ParentMenu
+-- not supported on Lobby and Pause menu yet
+function UIMenuProgressItem:LabelFont(itemFont)
+    if itemFont == nil then
+        return self.Base:LabelFont()
+    end
+    self.Base:LabelFont(itemFont, self)
+end
+
+-- not supported on Lobby and Pause menu yet
+function UIMenuProgressItem:RightLabelFont(itemFont)
+    if itemFont == nil then
+        return self.Base:RightLabelFont()
+    end
+    self.Base:RightLabelFont(itemFont, self)
+end
+
+---Set the Parent Menu of the Item
+---@param menu UIMenu
+---@return UIMenu? -- returns the parent menu if no menu is passed, if a menu is passed it returns the menu if it was set successfully
+function UIMenuProgressItem:SetParentMenu(menu)
+    if menu == nil then
+        return self.Base:SetParentMenu()
+    end
+    self.Base:SetParentMenu(menu)
+end
+
+function UIMenuProgressItem:Selected(bool)
+    if bool == nil then
+        return self.Base:Selected()
+    end
+    self.Base:Selected(bool, self)
+end
+
+function UIMenuProgressItem:Hovered(bool)
+    if bool == nil then
+        return self.Base:Hovered()
+    end
+    self.Base:Hovered(bool)
+end
+
+function UIMenuProgressItem:Enabled(bool)
+    if bool == nil then
+        return self.Base:Enabled()
+    end
+    self.Base:Hovered(bool, self)
+end
+
+function UIMenuProgressItem:Description(str)
+    if str == nil then
+        return self.Base:Description()
+    end
+    self.Base:Description(str, self)
+end
+
+function UIMenuProgressItem:MainColor(color)
+    if color == nil then
+        return self.Base:MainColor()
+    end
+    self.Base:MainColor(color, self)
+end
+
+function UIMenuProgressItem:HighlightColor(color)
+    if color == nil then
+        return self.Base:HighlightColor()
+    end
+    self.Base:HighlightColor(color, self)
+end
+
+function UIMenuProgressItem:Label(Text)
+    if Text == nil then
+        return self.Base:Label()
+    end
+    self.Base:Label(Text, self)
+end
+
+function UIMenuProgressItem:BlinkDescription(bool)
+    if bool == nil then
+        return self.Base:BlinkDescription()
+    end
+    self.Base:BlinkDescription(bool, self)
+end
+
+function UIMenuProgressItem:LeftBadge(Badge)
+    if Badge == nil then
+        return self.Base:LeftBadge()
+    end
+    self.Base:LeftBadge(Badge, self)
+end
+
+function UIMenuProgressItem:CustomLeftBadge(txd,txn)
+    self.Base:CustomLeftBadge(txd,txn, self)
+end
+
+---RightBadge
+function UIMenuProgressItem:RightBadge()
+    error("This item does not support right badges")
+end
+
+function UIMenuProgressItem:CustomRightBadge()
+    error("This item does not support right badges")
+end
+
+---RightLabel
+function UIMenuProgressItem:RightLabel()
+    error("This item does not support a right label")
+end
+
+
+function UIMenuProgressItem:AddPanel(Panel)
+    if Panel() == "UIMenuPanel" then
+        Panel.ParentItem = self
+        self.Panels[#self.Panels + 1] = Panel
     end
 end
 
 function UIMenuProgressItem:AddSidePanel(sidePanel)
-    if sidePanel() == "UIMissionDetailsPanel" then
-        sidePanel:SetParentItem(self)
-        self.SidePanel = sidePanel
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), 0, sidePanel.PanelSide, sidePanel.TitleType,
-                sidePanel.Title,
-                sidePanel.TitleColor, sidePanel.TextureDict, sidePanel.TextureName)
+    sidePanel:SetParentItem(self)
+    self.SidePanel = sidePanel
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it)
+    end
+end
+
+function UIMenuProgressItem:RemoveSidePanel()
+    self.SidePanel = nil
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it)
+    end
+end
+
+function UIMenuProgressItem:RemovePanelAt(Index)
+    if tonumber(Index) then
+        if self.Panels[Index] then
+            table.remove(self.Panels, tonumber(Index))
+            local it = IndexOf(self.ParentMenu.Items, self)
+            self.ParentMenu:SendPanelsToItemScaleform(it)
         end
-    elseif sidePanel() == "UIVehicleColorPickerPanel" then
-        sidePanel:SetParentItem(self)
-        self.SidePanel = sidePanel
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM",
-                IndexOf(self.Base.ParentMenu.Items, self), 1, sidePanel.PanelSide, sidePanel.TitleType, sidePanel.Title,
-                sidePanel.TitleColor)
+    end
+end
+
+function UIMenuProgressItem:FindPanelIndex(Panel)
+    if Panel() == "UIMenuPanel" then
+        for Index = 1, #self.Panels do
+            if self.Panels[Index] == Panel then
+                return Index
+            end
         end
     end
+    return nil
 end
 
----Selected
----@param bool number
-function UIMenuProgressItem:Selected(bool)
-    if bool ~= nil then
-        self.Base:Selected(ToBool(bool), self)
-    else
-        return self.Base._Selected
-    end
-end
-
----Hovered
----@param bool boolean
-function UIMenuProgressItem:Hovered(bool)
-    if bool ~= nil then
-        self.Base._Hovered = ToBool(bool)
-    else
-        return self.Base._Hovered
-    end
-end
-
----Enabled
----@param bool boolean
-function UIMenuProgressItem:Enabled(bool)
-    if bool ~= nil then
-        self.Base:Enabled(bool, self)
-    else
-        return self.Base._Enabled
-    end
-end
-
----Description
----@param str string
-function UIMenuProgressItem:Description(str)
-    if tostring(str) and str ~= nil then
-        self.Base:Description(tostring(str), self)
-    else
-        return self.Base._Description
-    end
-end
-
----Text
----@param Text string
-function UIMenuProgressItem:Label(Text)
-    if tostring(Text) and Text ~= nil then
-        self.Base:Label(tostring(Text), self)
-    else
-        return self.Base:Label()
-    end
-end
-
-function UIMenuProgressItem:MainColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._mainColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
+function UIMenuProgressItem:FindPanelItem()
+    for Index = #self.Items, 1, -1 do
+        if self.Items[Index].Panel then
+            return Index
         end
-    else
-        return self.Base._mainColor
     end
-end
-
-function UIMenuProgressItem:TextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._textColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._textColor
-    end
-end
-
-function UIMenuProgressItem:HighlightColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightColor
-    end
-end
-
-function UIMenuProgressItem:HighlightedTextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightedTextColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightedTextColor
-    end
+    return nil
 end
 
 function UIMenuProgressItem:SliderColor(color)
     if color then
         assert(color() == "SColor", "Color must be SColor type")
-        self.SliderColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor,
-                self.SliderColor)
+        self._sliderColor = color
+        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() then
+            local it = IndexOf(self.Base.ParentMenu.Items, self)
+            self.Base.ParentMenu:SendItemToScaleform(it, true)
         end
     else
-        return self.SliderColor
-    end
-end
-
-function UIMenuProgressItem:LabelFont(fontTable)
-    if fontTable == nil then
-        return self.Base:LabelFont()
-    else
-        self.Base:LabelFont(fontTable)
-    end
-end
-
-function UIMenuProgressItem:BlinkDescription(bool)
-    if bool ~= nil then
-        self.Base:BlinkDescription(bool, self)
-    else
-        return self.Base:BlinkDescription()
+        return self._sliderColor
     end
 end
 
@@ -219,51 +229,11 @@ function UIMenuProgressItem:Index(Index)
             self._Index = Index
         end
         self.OnProgressChanged(self._Index)
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_ITEM_VALUE",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), self._Index)
+        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() then
+            local it = IndexOf(self.Base.ParentMenu.Items, self)
+            self.Base.ParentMenu:SendItemToScaleform(it, true)
         end
     else
         return self._Index
     end
-end
-
----AddPanel
----@param panel UIMenuStatisticsPanel|UIMenuPercentagePanel|UIMenuColorPanel|UIMenuGridPanel
-function UIMenuProgressItem:AddPanel(panel)
-    if panel() == "UIMenuPanel" then
-        panel.ParentItem = self
-        self.Panels[#self.Panels + 1] = panel
-    end
-end
-
----LeftBadge
-function UIMenuProgressItem:LeftBadge(Badge)
-    if tonumber(Badge) then
-        self.Base:LeftBadge(Badge, self)
-    else
-        return self.Base:LeftBadge()
-    end
-end
-
-function UIMenuProgressItem:CustomLeftBadge(txd,txn)
-    if txd ~= nil and txd ~= "" and txn ~= nil and txn ~= "" then
-        self.Base:CustomLeftBadge(txd,txn, self)
-    else
-        return self.Base:LeftBadge()
-    end
-end
-
----RightBadge
-function UIMenuProgressItem:RightBadge()
-    error("This item does not support right badges")
-end
-
-function UIMenuProgressItem:CustomRightBadge()
-    error("This item does not support right badges")
-end
-
----RightLabel
-function UIMenuProgressItem:RightLabel()
-    error("This item does not support a right label")
 end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuSeperatorItem.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuSeperatorItem.lua
@@ -14,7 +14,7 @@ UIMenuSeparatorItem.__call = function() return "UIMenuItem", "UIMenuSeparatorIte
 ---@param highlightedTextColor? SColor
 function UIMenuSeparatorItem.New(Text, jumpable, mainColor, highlightColor, textColor, highlightedTextColor)
     local _UIMenuSeparatorItem = {
-        Base = UIMenuItem.New(Text or "", "", mainColor or SColor.HUD_Panel_light, highlightColor or SColor.HUD_White, textColor or SColor.HUD_White, highlightedTextColor or SColor.HUD_Black),
+        Base = UIMenuItem.New(Text or "", "", mainColor or SColor.HUD_Panel_light, highlightColor or SColor.HUD_White),
         Panels = {},
         SidePanel = nil,
         Jumpable = jumpable,
@@ -25,139 +25,147 @@ end
 
 function UIMenuSeparatorItem:ItemData(data)
     if data == nil then
-        return self.Base._itemData
+        return self.Base:ItemData(data)
     else
-        self.Base._itemData = data
-    end
-end
-
----SetParentMenu
----@param Menu table
-function UIMenuSeparatorItem:SetParentMenu(Menu)
-    if Menu() == "UIMenu" then
-        self.Base.ParentMenu = Menu
-    else
-        return self.Base.ParentMenu
-    end
-end
-
----Description
----@param str string
-function UIMenuSeparatorItem:Description(str)
-    if tostring(str) and str ~= nil then
-        self.Base:Description(tostring(str), self)
-    else
-        return self.Base._Description
-    end
-end
-
----Text
----@param Text string
-function UIMenuSeparatorItem:Label(Text)
-    if tostring(Text) and Text ~= nil then
-        self.Base:Label(tostring(Text), self)
-    else
-        return self.Base:Label()
-    end
-end
-
-function UIMenuSeparatorItem:MainColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._mainColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._mainColor
-    end
-end
-
-function UIMenuSeparatorItem:TextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._textColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._textColor
-    end
-end
-
-function UIMenuSeparatorItem:HighlightColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightColor
-    end
-end
-
-function UIMenuSeparatorItem:HighlightedTextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightedTextColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightedTextColor
+        self.Base:ItemData()
     end
 end
 
 -- not supported on Lobby and Pause menu yet
-function UIMenuSeparatorItem:LabelFont(fontTable)
-    if fontTable == nil then
+function UIMenuSeparatorItem:LabelFont(itemFont)
+    if itemFont == nil then
         return self.Base:LabelFont()
-    else
-        self.Base:LabelFont(fontTable)
     end
+    self.Base:LabelFont(itemFont, self)
 end
 
----Selected
----@param bool number
+-- not supported on Lobby and Pause menu yet
+function UIMenuSeparatorItem:RightLabelFont(itemFont)
+    if itemFont == nil then
+        return self.Base:RightLabelFont()
+    end
+    self.Base:RightLabelFont(itemFont, self)
+end
+
+---Set the Parent Menu of the Item
+---@param menu UIMenu
+---@return UIMenu? -- returns the parent menu if no menu is passed, if a menu is passed it returns the menu if it was set successfully
+function UIMenuSeparatorItem:SetParentMenu(menu)
+    if menu == nil then
+        return self.Base:SetParentMenu()
+    end
+    self.Base:SetParentMenu(menu)
+end
+
 function UIMenuSeparatorItem:Selected(bool)
-    if bool ~= nil then
-        self.Base:Selected(ToBool(bool), self)
-    else
-        return self.Base._Selected
+    if bool == nil then
+        return self.Base:Selected()
     end
+    self.Base:Selected(bool, self)
 end
 
----Hovered
----@param bool boolean
 function UIMenuSeparatorItem:Hovered(bool)
-    if bool ~= nil then
-        self.Base._Hovered = ToBool(bool)
-    else
-        return self.Base._Hovered
+    if bool == nil then
+        return self.Base:Hovered()
     end
+    self.Base:Hovered(bool)
 end
 
----Enabled
----@param bool boolean
 function UIMenuSeparatorItem:Enabled(bool)
-    if bool ~= nil then
-        self.Base:Enabled(bool, self)
-    else
-        return self.Base._Enabled
+    if bool == nil then
+        return self.Base:Enabled()
     end
+    self.Base:Hovered(bool, self)
+end
+
+function UIMenuSeparatorItem:Description(str)
+    if str == nil then
+        return self.Base:Description()
+    end
+    self.Base:Description(str, self)
+end
+
+function UIMenuSeparatorItem:MainColor(color)
+    if color == nil then
+        return self.Base:MainColor()
+    end
+    self.Base:MainColor(color, self)
+end
+
+function UIMenuSeparatorItem:HighlightColor(color)
+    if color == nil then
+        return self.Base:HighlightColor()
+    end
+    self.Base:HighlightColor(color, self)
+end
+
+function UIMenuSeparatorItem:Label(Text)
+    if Text == nil then
+        return self.Base:Label()
+    end
+    self.Base:Label(Text, self)
 end
 
 function UIMenuSeparatorItem:BlinkDescription(bool)
-    if bool ~= nil then
-        self.Base:BlinkDescription(bool, self)
-    else
+    if bool == nil then
         return self.Base:BlinkDescription()
     end
+    self.Base:BlinkDescription(bool, self)
+end
+
+
+function UIMenuSeparatorItem:AddPanel(Panel)
+    if Panel() == "UIMenuPanel" then
+        Panel.ParentItem = self
+        self.Panels[#self.Panels + 1] = Panel
+    end
+end
+
+function UIMenuSeparatorItem:AddSidePanel(sidePanel)
+    sidePanel:SetParentItem(self)
+    self.SidePanel = sidePanel
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it)
+    end
+end
+
+function UIMenuSeparatorItem:RemoveSidePanel()
+    self.SidePanel = nil
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it)
+    end
+end
+
+function UIMenuSeparatorItem:RemovePanelAt(Index)
+    if tonumber(Index) then
+        if self.Panels[Index] then
+            table.remove(self.Panels, tonumber(Index))
+            local it = IndexOf(self.ParentMenu.Items, self)
+            self.ParentMenu:SendPanelsToItemScaleform(it)
+        end
+    end
+end
+
+function UIMenuSeparatorItem:FindPanelIndex(Panel)
+    if Panel() == "UIMenuPanel" then
+        for Index = 1, #self.Panels do
+            if self.Panels[Index] == Panel then
+                return Index
+            end
+        end
+    end
+    return nil
+end
+
+function UIMenuSeparatorItem:FindPanelItem()
+    for Index = #self.Items, 1, -1 do
+        if self.Items[Index].Panel then
+            return Index
+        end
+    end
+    return nil
 end
 
 ---LeftBadge

--- a/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuStatsItem.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/Items/UIMenuStatsItem.lua
@@ -13,11 +13,9 @@ UIMenuStatsItem.__call = function() return "UIMenuItem", "UIMenuStatsItem" end
 ---@param type number|0
 ---@param mainColor SColor
 ---@param highlightColor SColor
----@param textColor SColor
----@param highlightedTextColor SColor
-function UIMenuStatsItem.New(Text, Description, Index, barColor, type, mainColor, highlightColor, textColor, highlightedTextColor)
+function UIMenuStatsItem.New(Text, Description, Index, barColor, type, mainColor, highlightColor)
     local _UIMenuStatsItem = {
-        Base = UIMenuItem.New(Text or "", Description or "", SColor.HUD_Panel_light, highlightColor or SColor.HUD_White, textColor or SColor.HUD_White, highlightedTextColor or SColor.HUD_Black),
+        Base = UIMenuItem.New(Text or "", Description or "", SColor.HUD_Panel_light, highlightColor or SColor.HUD_White),
         _Index = Index or 0,
         Panels = {},
         SidePanel = nil,
@@ -34,186 +32,92 @@ end
 
 function UIMenuStatsItem:ItemData(data)
     if data == nil then
-        return self.Base._itemData
+        return self.Base:ItemData(data)
     else
-        self.Base._itemData = data
+        self.Base:ItemData()
     end
 end
 
----SetParentMenu
----@param Menu table
-function UIMenuStatsItem:SetParentMenu(Menu)
-    if Menu() == "UIMenu" then
-        self.Base.ParentMenu = Menu
-    else
-        return self.Base.ParentMenu
+-- not supported on Lobby and Pause menu yet
+function UIMenuStatsItem:LabelFont(itemFont)
+    if itemFont == nil then
+        return self.Base:LabelFont()
     end
+    self.Base:LabelFont(itemFont, self)
 end
 
-function UIMenuStatsItem:AddSidePanel(sidePanel)
-    if sidePanel() == "UIMissionDetailsPanel" then
-        sidePanel:SetParentItem(self)
-        self.SidePanel = sidePanel
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), 0, sidePanel.PanelSide, sidePanel.TitleType,
-                sidePanel.Title,
-                sidePanel.TitleColor, sidePanel.TextureDict, sidePanel.TextureName)
-        end
-    elseif sidePanel() == "UIVehicleColorPickerPanel" then
-        sidePanel:SetParentItem(self)
-        self.SidePanel = sidePanel
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM",
-                IndexOf(self.Base.ParentMenu.Items, self), 1, sidePanel.PanelSide, sidePanel.TitleType, sidePanel.Title,
-                sidePanel.TitleColor)
-        end
+-- not supported on Lobby and Pause menu yet
+function UIMenuStatsItem:RightLabelFont(itemFont)
+    if itemFont == nil then
+        return self.Base:RightLabelFont()
     end
+    self.Base:RightLabelFont(itemFont, self)
 end
 
----Selected
----@param bool number
+---Set the Parent Menu of the Item
+---@param menu UIMenu
+---@return UIMenu? -- returns the parent menu if no menu is passed, if a menu is passed it returns the menu if it was set successfully
+function UIMenuStatsItem:SetParentMenu(menu)
+    if menu == nil then
+        return self.Base:SetParentMenu()
+    end
+    self.Base:SetParentMenu(menu)
+end
+
 function UIMenuStatsItem:Selected(bool)
-    if bool ~= nil then
-        self.Base:Selected(ToBool(bool), self)
-    else
-        return self.Base._Selected
+    if bool == nil then
+        return self.Base:Selected()
     end
+    self.Base:Selected(bool, self)
 end
 
----Hovered
----@param bool boolean
 function UIMenuStatsItem:Hovered(bool)
-    if bool ~= nil then
-        self.Base._Hovered = ToBool(bool)
-    else
-        return self.Base._Hovered
+    if bool == nil then
+        return self.Base:Hovered()
     end
+    self.Base:Hovered(bool)
 end
 
----Enabled
----@param bool boolean
 function UIMenuStatsItem:Enabled(bool)
-    if bool ~= nil then
-        self.Base:Enabled(bool, self)
-    else
-        return self.Base._Enabled
+    if bool == nil then
+        return self.Base:Enabled()
     end
+    self.Base:Hovered(bool, self)
 end
 
----Description
----@param str string
 function UIMenuStatsItem:Description(str)
-    if tostring(str) and str ~= nil then
-        self.Base:Description(tostring(str), self)
-    else
-        return self.Base._Description
+    if str == nil then
+        return self.Base:Description()
     end
-end
-
----Text
----@param Text string
-function UIMenuStatsItem:Label(Text)
-    if tostring(Text) and Text ~= nil then
-        self.Base:Label(tostring(Text), self)
-    else
-        return self.Base:Label()
-    end
+    self.Base:Description(str, self)
 end
 
 function UIMenuStatsItem:MainColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._mainColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._mainColor
+    if color == nil then
+        return self.Base:MainColor()
     end
-end
-
-function UIMenuStatsItem:TextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._textColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._textColor
-    end
+    self.Base:MainColor(color, self)
 end
 
 function UIMenuStatsItem:HighlightColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightColor
+    if color == nil then
+        return self.Base:HighlightColor()
     end
+    self.Base:HighlightColor(color, self)
 end
 
-function UIMenuStatsItem:HighlightedTextColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self.Base._highlightedTextColor = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor)
-        end
-    else
-        return self.Base._highlightedTextColor
+function UIMenuStatsItem:Label(Text)
+    if Text == nil then
+        return self.Base:Label()
     end
-end
-
-function UIMenuStatsItem:SliderColor(color)
-    if color then
-        assert(color() == "SColor", "Color must be SColor type")
-        self._Color = color
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_COLORS", self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)),
-                self.Base._mainColor, self.Base._highlightColor, self.Base._textColor, self.Base._highlightedTextColor,
-                self._Color)
-        end
-    else
-        return self._Color
-    end
+    self.Base:Label(Text, self)
 end
 
 function UIMenuStatsItem:BlinkDescription(bool)
-    if bool ~= nil then
-        self.Base:BlinkDescription(bool, self)
-    else
+    if bool == nil then
         return self.Base:BlinkDescription()
     end
-end
-
----Index
----@param Index table
-function UIMenuStatsItem:Index(Index)
-    if tonumber(Index) then
-        if Index > 100 then
-            self._Index = 100
-        elseif Index < 0 then
-            self._Index = 0
-        else
-            self._Index = Index
-        end
-        self.OnStatsChanged(self._Index)
-        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() and self.Base.ParentMenu.Pagination:IsItemVisible(IndexOf(self.Base.ParentMenu.Items, self)) then
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_ITEM_VALUE",
-                self.Base.ParentMenu.Pagination:GetScaleformIndex(IndexOf(self.Base.ParentMenu.Items, self)), self._Index)
-        end
-    else
-        return self._Index
-    end
+    self.Base:BlinkDescription(bool, self)
 end
 
 ---LeftBadge
@@ -237,4 +141,93 @@ end
 ---RightLabel
 function UIMenuStatsItem:RightLabel()
     error("This item does not support a right label")
+end
+
+
+function UIMenuStatsItem:AddPanel(Panel)
+    if Panel() == "UIMenuPanel" then
+        Panel.ParentItem = self
+        self.Panels[#self.Panels + 1] = Panel
+    end
+end
+
+function UIMenuStatsItem:AddSidePanel(sidePanel)
+    sidePanel:SetParentItem(self)
+    self.SidePanel = sidePanel
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it)
+    end
+end
+
+function UIMenuStatsItem:RemoveSidePanel()
+    self.SidePanel = nil
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it)
+    end
+end
+
+function UIMenuStatsItem:RemovePanelAt(Index)
+    if tonumber(Index) then
+        if self.Panels[Index] then
+            table.remove(self.Panels, tonumber(Index))
+            local it = IndexOf(self.ParentMenu.Items, self)
+            self.ParentMenu:SendPanelsToItemScaleform(it)
+        end
+    end
+end
+
+function UIMenuStatsItem:FindPanelIndex(Panel)
+    if Panel() == "UIMenuPanel" then
+        for Index = 1, #self.Panels do
+            if self.Panels[Index] == Panel then
+                return Index
+            end
+        end
+    end
+    return nil
+end
+
+function UIMenuStatsItem:FindPanelItem()
+    for Index = #self.Items, 1, -1 do
+        if self.Items[Index].Panel then
+            return Index
+        end
+    end
+    return nil
+end
+
+function UIMenuStatsItem:SliderColor(color)
+    if color then
+        assert(color() == "SColor", "Color must be SColor type")
+        self._Color = color
+        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() then
+            local it = IndexOf(self.Base.ParentMenu.Items, self)
+            self.Base.ParentMenu:SendItemToScaleform(it, true)
+        end
+    else
+        return self._Color
+    end
+end
+
+---Index
+---@param Index table
+function UIMenuStatsItem:Index(Index)
+    if tonumber(Index) then
+        if Index > 100 then
+            self._Index = 100
+        elseif Index < 0 then
+            self._Index = 0
+        else
+            self._Index = Index
+        end
+        self.OnStatsChanged(self._Index)
+        if self.Base.ParentMenu ~= nil and self.Base.ParentMenu:Visible() then
+            local it = IndexOf(self.Base.ParentMenu.Items, self)
+            self.Base.ParentMenu:SendItemToScaleform(it, true)
+        end
+    else
+        return self._Index
+    end
 end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
@@ -908,7 +908,7 @@ function UIMenu:SendPanelsToItemScaleform(i, update)
             ScaleformUI.Scaleforms._ui:CallFunction(str, index - 1, pan - 1, 4)
         end
     end
-    if not update then
+    if (not update) then
         ScaleformUI.Scaleforms._ui:CallFunction("SHOW_PANELS")
     end
 end
@@ -1752,7 +1752,7 @@ function UIMenu:ProcessMouse()
                 panel.OnGridPanelChanged(panel.ParentItem, panel, panel._CirclePosition)
             elseif panel_subtype == "UIMenuPercentagePanel" then
                 panel._percentage = tonumber(split[2])
-                self:OnPercentagePanelChanged(panel.ParentItem, panel, panel._percentage)
+                self.OnPercentagePanelChanged(panel.ParentItem, panel, panel._percentage)
                 panel.OnPercentagePanelChange(panel.ParentItem, panel, panel._percentage)
             end
         end)

--- a/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
@@ -588,7 +588,8 @@ function UIMenu:AddItem(item)
     item:SetParentMenu(self)
     self.Items[#self.Items + 1] = item
     if self:Visible() then
-        self:RefreshMenu(true)
+        local idx = #self.Items - 1
+        self:SendItemToScaleform(idx)
     end
     -- add build new item (sent slot)
 end
@@ -601,7 +602,7 @@ function UIMenu:AddItemAt(item, index)
     item:SetParentMenu(self)
     table.insert(self.Items, index, item)
     if self:Visible() then
-        self:RefreshMenu(true)
+        self:SendItemToScaleform(index, false, true)
     end
 end
 
@@ -807,6 +808,9 @@ end
 function UIMenu:SendItems()
     ScaleformUI.Scaleforms._ui:CallFunction("SET_DATA_SLOT_EMPTY")
     for k,v in pairs(self.Items) do
+        if(#self.Items < k) then
+            break
+        end
         self:SendItemToScaleform(k, false)
         if self._visibleItems < self:MaxItemsOnScreen() then
             self._visibleItems = self._visibleItems + 1
@@ -898,12 +902,16 @@ function UIMenu:SendPanelsToItemScaleform(i, update)
     ScaleformUI.Scaleforms._ui:CallFunction("SHOW_PANELS")
 end
 
-function UIMenu:SendItemToScaleform(i, update)
+function UIMenu:SendItemToScaleform(i, update, newItem)
     if update == nil then update = false end
+    if newItem == nil then newItem = false end
     local item = self.Items[i]
-    local str = "UPDATE_DATA_SLOT"
-    if not update then
-        str = "SET_DATA_SLOT"
+    local str = "SET_DATA_SLOT"
+    if update then
+        str = "UPDATE_DATA_SLOT"
+    end
+    if newItem then
+        str = "SET_DATA_SLOT_SPLICE"
     end
     local Type, SubType = item()
     local it = item

--- a/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/UIMenu.lua
@@ -109,7 +109,7 @@ end
 ---@param txtDictionary string|nil -- Custom texture dictionary for the menu banner background (default: commonmenu)
 ---@param txtName string|nil -- Custom texture name for the menu banner background (default: interaction_bgd)
 ---@param alternativeTitleStyle boolean|nil -- Use alternative title style (default: false)
-function UIMenu.New(title, subTitle, x, y, glare, txtDictionary, txtName, alternativeTitleStyle, fadeTime, longdesc, align)
+function UIMenu.New(title, subTitle, x, y, glare, txtDictionary, txtName, alternativeTitleStyle, longdesc, align)
     local X, Y = tonumber(x) or 0, tonumber(y) or 0
     if title ~= nil then
         title = tostring(title) or ""
@@ -142,15 +142,14 @@ function UIMenu.New(title, subTitle, x, y, glare, txtDictionary, txtName, altern
         _Subtitle = subTitle,
         AlternativeTitle = alternativeTitleStyle,
         counterColor = SColor.HUD_Freemode,
-        Position = vector2(X,Y),
-        Pagination = PaginationHandler.New(),
-        enableAnimation = true,
-        animationType = MenuAnimationType.LINEAR,
-        buildingAnimation = MenuBuildingAnimation.NONE,
-        scrollingType = MenuScrollingType.CLASSIC,
+        Position = vector2(X, Y),
         descFont = ScaleformFonts.CHALET_LONDON_NINETEENSIXTY,
         subtitleColor = HudColours.NONE,
         leftClickEnabled = false,
+        _maxItemsOnScreen = 7,
+        _currentSelection = 1,
+        _visibleItems = 1,
+        topEdge = 1,
         bannerColor = SColor.HUD_None,
         Extra = {},
         Description = {},
@@ -178,14 +177,13 @@ function UIMenu.New(title, subTitle, x, y, glare, txtDictionary, txtName, altern
         _differentBanner = false,
         _canHe = true,
         _scaledWidth = (720 * GetAspectRatio(false)),
-        _glarePos = {x=0,y=0},
-        _glareSize = {w=1.0,h=1.0},
+        _glarePos = { x = 0, y = 0 },
+        _glareSize = { w = 1.0, h = 1.0 },
         menuAlignment = align or 0,
         _mouseOnMenu = false,
         fSavedGlareDirection = 0,
         enabled3DAnimations = true,
         isFading = false,
-        fadingTime = fadeTime or 0.1,
         Controls = {
             Back = {
                 Enabled = true,
@@ -264,7 +262,6 @@ function UIMenu.New(title, subTitle, x, y, glare, txtDictionary, txtName, altern
             },
         }
     }
-    _UIMenu.Pagination.itemsPerPage = 7
     if subTitle ~= "" and subTitle ~= nil then
         _UIMenu._Subtitle = subTitle
     end
@@ -272,30 +269,22 @@ function UIMenu.New(title, subTitle, x, y, glare, txtDictionary, txtName, altern
         _UIMenu._menuGlare = Scaleform.Request("mp_menu_glare")
     end
 
-    _UIMenu.Position = vector2(X,Y)
-    local safezone = (1.0 - math.round(GetSafeZoneSize(), 2)) * 100 * 0.005;
+    _UIMenu.Position = vector2(X, Y)
+    local safezone = (1.0 - math.round(GetSafeZoneSize(), 2)) * 100 * 0.005
     local rightAlign = _UIMenu.menuAlignment == MenuAlignment.RIGHT
-    local glareX = 0.45
-    local glareW = 1.0
-    if not GetWideScreen() then
-        glareX = 0.585
-        glareW = 1.35
-    end
+    local glareX = 0.45 + safezone
 
-    local pos1080 = ConvertScaleformCoordsToResolutionCoords(X,Y)
-    local screenCoords = ConvertResolutionCoordsToScreenCoords(pos1080.x,pos1080.y)
-    _UIMenu._glarePos = vector2(screenCoords.x + glareX + safezone, screenCoords.y + 0.45 + safezone)
+    local pos1080 = ConvertScaleformCoordsToResolutionCoords(X, Y)
+    local screenCoords = ConvertResolutionCoordsToScreenCoords(pos1080.x, pos1080.y)
+    _UIMenu._glarePos = vector2(screenCoords.x + glareX, screenCoords.y + 0.45 + safezone)
     if rightAlign then
-        local w,h = GetActualScreenResolution()
-        screenCoords = ConvertResolutionCoordsToScreenCoords(w - pos1080.x,pos1080.y)
-        glareX = 0.225
-        if not GetWideScreen() then
-            glareX = 0.36
-        end
-        _UIMenu._glarePos = vector2(screenCoords.x + glareX - safezone, screenCoords.y + 0.45 + safezone)
+        glareX = 1.225 - safezone
+        local w, h = GetActualScreenResolution()
+        screenCoords = ConvertResolutionCoordsToScreenCoords(1920 - pos1080.x, pos1080.y)
+        _UIMenu._glarePos = vector2(screenCoords.x - 1 + glareX, screenCoords.y + 0.45 + safezone)
     end
 
-    _UIMenu._glareSize = {w=glareW, h=1.0}
+    _UIMenu._glareSize = { w = glareW, h = 1.0 }
 
     return setmetatable(_UIMenu, UIMenu)
 end
@@ -313,7 +302,8 @@ function UIMenu:Title(title)
                 ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_TITLE_SUBTITLE", self._Title, self._Subtitle,
                     self.alternativeTitle)
             else
-                ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_TITLE_SUBTITLE", self._Title, "~HC_" .. self.subtitleColor .. "~" .. self._Subtitle,
+                ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_TITLE_SUBTITLE", self._Title,
+                    "~HC_" .. self.subtitleColor .. "~" .. self._Subtitle,
                     self.alternativeTitle)
             end
         end
@@ -329,7 +319,7 @@ function UIMenu:DescriptionFont(fontTable)
     else
         self.descFont = fontTable
         if self:Visible() then
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_DESC_FONT", self.descFont.FontName, self.descFont.FontID)
+            self:SetMenuData(true)
         end
     end
 end
@@ -343,13 +333,7 @@ function UIMenu:Subtitle(sub)
     else
         self._Subtitle = sub
         if self:Visible() then
-            if self.subtitleColor == HudColours.NONE then
-                ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_TITLE_SUBTITLE", self._Title, self._Subtitle,
-                    self.alternativeTitle)
-            else
-                ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_TITLE_SUBTITLE", self._Title, "~HC_" .. self.subtitleColor .. "~" .. self._Subtitle,
-                    self.alternativeTitle)
-            end
+            self:SetMenuData(true)
         end
     end
 end
@@ -363,7 +347,7 @@ function UIMenu:CounterColor(color)
     else
         self.counterColor = color
         if self:Visible() then
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_COUNTER_COLOR", self.counterColor)
+            self:SetMenuData(true)
         end
     end
 end
@@ -377,11 +361,7 @@ function UIMenu:SubtitleColor(color)
     else
         self.subtitleColor = color
         if self:Visible() then
-            if color == HudColours.NONE then
-                ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_TITLE_SUBTITLE", self._Title, self._Subtitle, self.alternativeTitle)
-            else
-                ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_TITLE_SUBTITLE", self._Title, "~HC_" .. self.subtitleColor .. "~" .. self._Subtitle, self.alternativeTitle)
-            end
+            self:SetMenuData(true)
         end
     end
 end
@@ -396,7 +376,7 @@ function UIMenu:MenuAlignment(align)
         self.menuAlignment = align
         self:SetMenuOffset(self.Position.x, self.Position.y)
         if self:Visible() then
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_MENU_ORIENTATION", align) 
+            self:SetMenuData(true)
         end
     end
 end
@@ -479,51 +459,12 @@ function UIMenu:RefreshMenu(keepIndex)
     if keepIndex == nil then keepIndex = false end
     if (self:Visible()) then
         local index = self:CurrentSelection()
-        self.BannerisBuilding = true
-        ScaleformUI.Scaleforms._ui:CallFunction("CLEAR_ITEMS")
-        for k, it in pairs(self.Items) do
-            it:Selected(false)
-        end
-
-        -- we want to keep the rebuild as clean as possible.. we disable all anims for the moment
-        local enableScrollingAnim = self:AnimationEnabled()
-        local enable3DAnim = self:Enabled3DAnimations()
-        local scrollingAnimation = self:AnimationType()
-        local buildingAnimation = self:BuildingAnimation()
-
-        self:SetMenuAnimations(false, false, MenuAnimationType.LINEAR, MenuBuildingAnimation.NONE)
-
-        if (#self.Items > 0) then
-            self.isBuilding = true
-            local max = self.Pagination:ItemsPerPage()
-            if (#self.Items < max) then
-                max = #self.Items
-            end
-
-            self.Pagination:MinItem(self.Pagination:CurrentPageStartIndex())
-            if (self.Pagination.scrollType == MenuScrollingType.CLASSIC and self.Pagination:TotalPages() > 1) then
-                local missingItems = self.Pagination:GetMissingItems()
-                if (missingItems > 0) then
-                    self.Pagination:ScaleformIndex(self.Pagination:GetPageIndexFromMenuIndex(self.Pagination:CurrentPageEndIndex()) + missingItems)
-                    self.Pagination:MinItem(self.Pagination:CurrentPageStartIndex() - missingItems)
-                end
-            end
-            self.Pagination:MaxItem(self.Pagination:CurrentPageEndIndex())
-
-            for i = 1, max, 1 do
-                if (not self:Visible()) then return end
-                self:_itemCreation(self.Pagination:CurrentPage(), i, false, true)
-            end
-            self.Pagination:ScaleformIndex(self.Pagination:GetScaleformIndex(self.Pagination:CurrentMenuIndex()))
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_COUNTER_QTTY", self:CurrentSelection(), #self.Items)
-            self.isBuilding = false
-            if keepIndex then
-                self:CurrentSelection(index)
-            else
-                self:CurrentSelection(0)
-            end
-
-            self:SetMenuAnimations(enableScrollingAnim, enable3DAnim, scrollingAnimation, buildingAnimation)
+        self:SendItems()
+        self.isBuilding = false
+        if keepIndex then
+            self:CurrentSelection(index)
+        else
+            self:CurrentSelection(0)
         end
     end
 end
@@ -535,7 +476,7 @@ function UIMenu:SetBannerSprite(txtDictionary, txtName)
     self.TxtDictionary = txtDictionary
     self.TxtName = txtName
     if self:Visible() then
-        ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_MENU_BANNER_TEXTURE", txtDictionary, txtName)
+        self:SetMenuData(true)
     end
 end
 
@@ -544,165 +485,74 @@ end
 function UIMenu:SetBannerColor(color)
     self.bannerColor = color
     if self:Visible() then
-        ScaleformUI.Scaleforms._ui:CallFunction("SET_MENU_BANNER_COLOR", color)
+        self:SetMenuData(true)
     end
 end
 
---- Handles all the menu animations in one place
----@param enableScrollingAnim boolean
----@param enable3DAnim boolean
----@param scrollingAnimation MenuAnimationType
----@param buildingAnimation MenuBuildingAnimation
----@param fadingTime number
+--- Legacy function to be removed
 function UIMenu:SetMenuAnimations(enableScrollingAnim, enable3DAnim, scrollingAnimation, buildingAnimation, fadingTime)
-    if scrollingAnimation == nil then
-        scrollingAnimation =  MenuAnimationType.QUADRATIC_IN
-    end
-    if buildingAnimation == nil then
-        buildingAnimation = MenuBuildingAnimation.LEFT_RIGHT
-    end
-    if fadingTime == nil then
-        fadingTime = 0.1
-    end
-
-    self:AnimationEnabled(enableScrollingAnim)
-    self:Enabled3DAnimations(enable3DAnim)
-    self:AnimationType(scrollingAnimation)
-    self:BuildingAnimation(buildingAnimation)
-    self.fadingTime = fadingTime
 end
 
---- Enables or disabls the menu's animations while the menu is visible.
+--- Legacy function to be removed.
 ---@param enable boolean|nil
 ---@return boolean
 function UIMenu:AnimationEnabled(enable)
-    if enable ~= nil then
-        self.enableAnimation = enable
-        if self:Visible() then
-            ScaleformUI.Scaleforms._ui:CallFunction("ENABLE_SCROLLING_ANIMATION", enable)
-        end
-    end
-    return self.enableAnimation
+    return false
 end
 
 function UIMenu:Enabled3DAnimations(enable)
-    if enable ~= nil then
-        self.enabled3DAnimations = enable
-        if self:Visible() then
-            ScaleformUI.Scaleforms._ui:CallFunction("ENABLE_3D_ANIMATIONS", enable)
-        end
-    else
-        return self.enabled3DAnimations
-    end
+    return false
 end
 
---- Sets the menu's scrolling animationType while the menu is visible.
+--- Legacy function to be removed.
 ---@param menuAnimationType MenuAnimationType|nil
 ---@return number MenuAnimationType
 ---@see MenuAnimationType
 function UIMenu:AnimationType(menuAnimationType)
-    if menuAnimationType ~= nil then
-        self.animationType = menuAnimationType
-        if self:Visible() then
-            ScaleformUI.Scaleforms._ui:CallFunction("CHANGE_SCROLLING_ANIMATION_TYPE", menuAnimationType)
-        end
-    end
-
-    return self.animationType
+    return 0
 end
 
---- Enables or disables the menu's building animationType.
+--- Legacy function to be removed
 ---@param buildingAnimationType MenuBuildingAnimation|nil
 ---@return MenuBuildingAnimation
 ---@see MenuBuildingAnimation
 function UIMenu:BuildingAnimation(buildingAnimationType)
-    if buildingAnimationType ~= nil then
-        self.buildingAnimation = buildingAnimationType
-        if self:Visible() then
-            ScaleformUI.Scaleforms._ui:CallFunction("CHANGE_BUILDING_ANIMATION_TYPE", buildingAnimationType)
-        end
-    end
-    return self.buildingAnimation
+    return 0
 end
 
---- Decides how menu behaves on scrolling and overflowing.
+--- Legacy function to be removed
 ---@param scrollType MenuScrollingType|nil
 ---@return MenuScrollingType
 ---@see MenuScrollingType
 function UIMenu:ScrollingType(scrollType)
-    if scrollType ~= nil then
-        self.scrollingType = scrollType
-        self.Pagination.scrollType = scrollType
-    end
-    return self.scrollingType
-end
-
-function UIMenu:FadeOutMenu()
-    ScaleformUI.Scaleforms._ui:CallFunction("FADE_OUT_MENU")
-    while self.isFading do
-        Citizen.Wait(0)
-        self.isFading = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnBool("GET_IS_FADING")
-    end
-end
-
-function UIMenu:FadeInMenu()
-    ScaleformUI.Scaleforms._ui:CallFunction("FADE_IN_MENU")
-
-    while self.isFading do
-        Citizen.Wait(0)
-        self.isFading = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnBool("GET_IS_FADING")
-    end
-end
-
-function UIMenu:FadeOutItems()
-    ScaleformUI.Scaleforms._ui:CallFunction("FADE_OUT_ITEMS")
-
-    while self.isFading do
-        Citizen.Wait(0)
-        self.isFading = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnBool("GET_IS_FADING")
-    end
-end
-
-function UIMenu:FadeInItems()
-    ScaleformUI.Scaleforms._ui:CallFunction("FADE_IN_ITEMS")
-
-    while self.isFading do
-        Citizen.Wait(0)
-        self.isFading = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnBool("GET_IS_FADING")
-    end
+    return 0
 end
 
 ---CurrentSelection
 ---@param value number|nil
 function UIMenu:CurrentSelection(value)
     if value ~= nil then
-        if value < 1 then
-            self.Pagination:CurrentMenuIndex(1)
-            value = 1
-        elseif value > #self.Items then
-            self.Pagination:CurrentMenuIndex(#self.Items)
-            value = #self.Items
-        end
-        if self:CurrentSelection() < #self.Items then
-            self.Items[self:CurrentSelection()]:Selected(false)
-        end
-        self.Pagination:CurrentMenuIndex(value)
-        self.Pagination:CurrentPage(self.Pagination:GetPage(self.Pagination:CurrentMenuIndex()))
-        self.Pagination:CurrentPageIndex(value)
-        self.Pagination:ScaleformIndex(self.Pagination:GetScaleformIndex(self.Pagination:CurrentMenuIndex()))
-        if (value > self.Pagination:MaxItem() or value < self.Pagination:MinItem()) then
-            self:RefreshMenu(true)
+        self:CurrentItem():Selected(false)
+        self._currentSelection = math.max(1, math.min(value, #self.Items))
+
+        if self._currentSelection >= self.topEdge + self._visibleItems then
+            self.topEdge = math.max(1, math.min(self._currentSelection, #self.Items - self._visibleItems))
+        elseif self._currentSelection < self.topEdge then
+            self.topEdge = self._currentSelection;
         end
 
         if self:Visible() then
-            AddTextEntry("UIMenu_Current_Description", self:CurrentItem():Description());
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_CURRENT_ITEM",
-                self.Pagination:GetScaleformIndex(self.Pagination:CurrentMenuIndex()))
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_COUNTER_QTTY", self:CurrentSelection(), #self.Items)
+            AddTextEntry("UIMenu_Current_Description", self:CurrentItem():Description())
+            ScaleformUI.Scaleforms._ui:CallFunction("SET_CURRENT_SELECTION", self._currentSelection - 1, self.topEdge - 1)
+            self:SendPanelsToItemScaleform(self._currentSelection)
+            self:SendSidePanelToScaleform(self._currentSelection)
         end
-        self.Items[value]:Selected(true)
+        self.Items[self._currentSelection]:Selected(true)
     else
-        return self.Pagination:CurrentMenuIndex()
+        if #self.Items == 0 then
+            return 1
+        end
+        return self._currentSelection
     end
 end
 
@@ -737,7 +587,10 @@ function UIMenu:AddItem(item)
     end
     item:SetParentMenu(self)
     self.Items[#self.Items + 1] = item
-    self.Pagination:TotalItems(#self.Items)
+    if self:Visible() then
+        self:RefreshMenu(true)
+    end
+    -- add build new item (sent slot)
 end
 
 function UIMenu:AddItemAt(item, index)
@@ -747,18 +600,8 @@ function UIMenu:AddItemAt(item, index)
     end
     item:SetParentMenu(self)
     table.insert(self.Items, index, item)
-    self.Pagination:TotalItems(#self.Items)
     if self:Visible() then
-        if self.Pagination:IsItemVisible(index) then
-            self:RefreshMenu()
-        end
-        local it = self.Items[self:CurrentSelection()]
-        local t, subt = it()
-        if subt == "UIMenuSeparatorItem" then
-            if it.Jumpable then
-                self:GoDown();
-            end
-        end
+        self:RefreshMenu(true)
     end
 end
 
@@ -768,9 +611,8 @@ function UIMenu:RemoveItemAt(index)
     if tonumber(index) then
         if self.Items[index] then
             table.remove(self.Items, index)
-            self.Pagination:TotalItems(#self.Items)
             if self:Visible() then
-                self:RefreshMenu(true);
+                self:RefreshMenu(true)
             end
         else
             print("ScaleformUI - UIMenu:RemoveItemAt - Index out of range (Index: " .. index .. ", Items: " .. #self.Items .. ")")
@@ -794,11 +636,9 @@ end
 
 ---Clear
 function UIMenu:Clear()
-    self.Pagination:CurrentMenuIndex(1)
     self.Items = {}
-    self.Pagination:Reset()
     if self:Visible() then
-        ScaleformUI.Scaleforms._ui:CallFunction("CLEAR_ITEMS")
+        ScaleformUI.Scaleforms._ui:CallFunction("SET_DATA_SLOT_EMPTY")
     end
 end
 
@@ -806,9 +646,10 @@ end
 ---@param max number|nil
 function UIMenu:MaxItemsOnScreen(max)
     if max == nil then
-        return self.Pagination:ItemsPerPage()
+        return self._maxItemsOnScreen
     end
-    self.Pagination:ItemsPerPage(max)
+    self._maxItemsOnScreen = max
+    self:BuildUpMenuAsync()
 end
 
 function UIMenu:SwitchTo(newMenu, newMenuCurrentSelection, inheritOldMenuParams)
@@ -835,64 +676,71 @@ function UIMenu:Visible(bool)
         self.Dirty = ToBool(bool)
 
         if bool then
-            if self._Visible then 
+            if self._Visible then
                 return
             end
-            self._Visible = bool;
+            self._Visible = bool
             if not self._itemless and #self.Items == 0 then
                 MenuHandler:CloseAndClearHistory()
-                assert(self._itemless or #self.Items == 0, "UIMenu " .. self:Title() .. " menu is empty... Closing and clearing history.")
+                assert(self._itemless or #self.Items == 0,
+                    "UIMenu " .. self:Title() .. " menu is empty... Closing and clearing history.")
             end
             ScaleformUI.Scaleforms.InstructionalButtons:SetInstructionalButtons(self.InstructionalButtons)
+            self:BuildUpMenuAsync()
             MenuHandler._currentMenu = self
             MenuHandler.ableToDraw = true
-            self:BuildUpMenuAsync()
             self.OnMenuOpen(self)
             if BreadcrumbsHandler:Count() == 0 then
                 BreadcrumbsHandler:Forward(self)
             end
+            AddTextEntry("UIMenu_Current_Description", self:CurrentItem():Description())
         else
-            self._Visible = bool;
-            self:FadeOutMenu()
+            self._Visible = bool
             ScaleformUI.Scaleforms.InstructionalButtons:ClearButtonList()
-            if BreadcrumbsHandler.SwitchInProgress and not self._differentBanner then
-                ScaleformUI.Scaleforms._ui:CallFunction("CLEAR_ITEMS")
-            else
-                ScaleformUI.Scaleforms._ui:CallFunction("CLEAR_ALL")
-            end
             MenuHandler._currentMenu = nil
             MenuHandler.ableToDraw = false
             self.OnMenuClose(self)
-            self:clearLabels()
         end
+        ScaleformUI.Scaleforms._ui:CallFunction("SET_VISIBLE", self._Visible, self:CurrentSelection() - 1, self.topEdge - 1)
+        self:SendPanelsToItemScaleform(self:CurrentSelection())
+        self:SendSidePanelToScaleform(self:CurrentSelection())
         if self.Settings.ResetCursorOnOpen then
             SetCursorLocation(0.5, 0.5)
+            SetCursorSprite(1)
         end
     else
         return self._Visible
     end
 end
 
-function UIMenu:clearLabels()
-    for k,v in ipairs(self.Items) do
-        AddTextEntry("menu_" .. (BreadcrumbsHandler:CurrentDepth() + 1) .. "_desc_" .. k, "")
-    end
-end
-
 ---BuildUpMenu
 function UIMenu:BuildUpMenuAsync(itemsOnly)
-    local time = GetNetworkTime()
     if itemsOnly == nil then itemsOnly = false end
     self._isBuilding = true
 
+    if (not itemsOnly) then
+        self:SetMenuData()
+        self:SetWindows()
+    end
+    if not self:Visible() then
+        return
+    end
+    self:SendItems()
+    ScaleformUI.Scaleforms._ui:CallFunction("ENABLE_MOUSE", self.Settings.MouseControlsEnabled)
+    self._isBuilding = false
+end
+
+function UIMenu:SetMenuData(skipViewInitialization)
+    if skipViewInitialization == nil then skipViewInitialization = false end
+    local subtitle = self._Subtitle
+    if self.subtitleColor ~= HudColours.NONE then
+        subtitle = "~HC_" .. self.subtitleColor .. "~" .. self._Subtitle
+    end
+
     if self._itemless then
-        BeginScaleformMovieMethod(ScaleformUI.Scaleforms._ui.handle, "CREATE_MENU")
+        BeginScaleformMovieMethod(ScaleformUI.Scaleforms._ui.handle, "SET_MENU_DATA")
         PushScaleformMovieMethodParameterString(self._Title)
-        if self.subtitleColor == HudColours.NONE then
-            PushScaleformMovieMethodParameterString(self._Subtitle)
-        else
-            PushScaleformMovieMethodParameterString("~HC_" .. self.subtitleColor .. "~" .. self._Subtitle)
-        end
+        PushScaleformMovieMethodParameterString(subtitle)
         PushScaleformMovieMethodParameterFloat(self.Position.x)
         PushScaleformMovieMethodParameterFloat(self.Position.y)
         PushScaleformMovieMethodParameterBool(self.AlternativeTitle)
@@ -900,326 +748,231 @@ function UIMenu:BuildUpMenuAsync(itemsOnly)
         PushScaleformMovieMethodParameterString(self.TxtName)
         PushScaleformMovieFunctionParameterInt(self:MaxItemsOnScreen())
         PushScaleformMovieFunctionParameterInt(#self.Items)
-        PushScaleformMovieFunctionParameterBool(self:AnimationEnabled())
-        PushScaleformMovieFunctionParameterInt(self:AnimationType())
-        PushScaleformMovieFunctionParameterInt(self:BuildingAnimation())
         PushScaleformMovieFunctionParameterInt(self.counterColor:ToArgb())
         PushScaleformMovieMethodParameterString(self.descFont.FontName)
         PushScaleformMovieFunctionParameterInt(self.descFont.FontID)
-        PushScaleformMovieMethodParameterFloat(self.fadingTime)
         PushScaleformMovieFunctionParameterInt(self.bannerColor:ToArgb())
         PushScaleformMovieFunctionParameterBool(true)
         BeginTextCommandScaleformString("ScaleformUILongDesc")
         EndTextCommandScaleformString_2()
-        PushScaleformMovieFunctionParameterInt(self.menuAlignment);
+        PushScaleformMovieMethodParameterString("")
+        PushScaleformMovieMethodParameterString("")
+        PushScaleformMovieFunctionParameterInt(self.menuAlignment)
+        PushScaleformMovieFunctionParameterBool(true)
         EndScaleformMovieMethod()
-        self:FadeInMenu()
         self._isBuilding = false
         return
     end
 
-    if not itemsOnly then
-        while not ScaleformUI.Scaleforms._ui:IsLoaded() do Citizen.Wait(0) end
-        if not BreadcrumbsHandler.SwitchInProgress or self._differentBanner then
-            if self.subtitleColor == HudColours.NONE then
-                ScaleformUI.Scaleforms._ui:CallFunction("CREATE_MENU", self._Title, self._Subtitle, self.Position.x,
-                    self.Position.y,
-                    self.AlternativeTitle, self.TxtDictionary, self.TxtName, self:MaxItemsOnScreen(), #self.Items, self:AnimationEnabled(),
-                    self:AnimationType(), self:BuildingAnimation(), self.counterColor, self.descFont.FontName,
-                    self.descFont.FontID, self.fadingTime, self.bannerColor:ToArgb(), false, "", "", "", self.menuAlignment)
-            else
-                ScaleformUI.Scaleforms._ui:CallFunction("CREATE_MENU", self._Title, "~HC_" .. self.subtitleColor .. "~" .. self._Subtitle, self.Position.x,
-                    self.Position.y,
-                    self.AlternativeTitle, self.TxtDictionary, self.TxtName, self:MaxItemsOnScreen(), #self.Items, self:AnimationEnabled(),
-                    self:AnimationType(), self:BuildingAnimation(), self.counterColor, self.descFont.FontName,
-                    self.descFont.FontID, self.fadingTime, self.bannerColor:ToArgb(), false, "", "", "", self.menuAlignment)
-            end
-        else
-            if self.subtitleColor == HudColours.NONE then
-                ScaleformUI.Scaleforms._ui:CallFunction("RE_CREATE_MENU", self._Title, self._Subtitle, self.Position.x,
-                    self.Position.y,
-                    self.AlternativeTitle, self.TxtDictionary, self.TxtName, self:MaxItemsOnScreen(), #self.Items, self:AnimationEnabled(),
-                    self:AnimationType(), self:BuildingAnimation(), self.counterColor, self.descFont.FontName,
-                    self.descFont.FontID, self.fadingTime, self.bannerColor:ToArgb(), false, "", "", "", self.menuAlignment)
-            else
-                ScaleformUI.Scaleforms._ui:CallFunction("RE_CREATE_MENU", self._Title, "~HC_" .. self.subtitleColor .. "~" .. self._Subtitle, self.Position.x,
-                    self.Position.y,
-                    self.AlternativeTitle, self.TxtDictionary, self.TxtName, self:MaxItemsOnScreen(), #self.Items, self:AnimationEnabled(),
-                    self:AnimationType(), self:BuildingAnimation(), self.counterColor, self.descFont.FontName,
-                    self.descFont.FontID, self.fadingTime, self.bannerColor:ToArgb(), false, "", "", "", self.menuAlignment)
-            end
-        end
-        if #self.Windows > 0 then
-            for w_id, window in pairs(self.Windows) do
-                local Type, SubType = window()
-                if SubType == "UIMenuHeritageWindow" then
-                    ScaleformUI.Scaleforms._ui:CallFunction("ADD_WINDOW", window.id, window.Mom, window.Dad)
-                elseif SubType == "UIMenuDetailsWindow" then
-                    ScaleformUI.Scaleforms._ui:CallFunction("ADD_WINDOW", window.id, window.DetailBottom,
-                        window.DetailMid, window.DetailTop, window.DetailLeft.Txd, window.DetailLeft.Txn,
-                        window.DetailLeft.Pos.x, window.DetailLeft.Pos.y, window.DetailLeft.Size.x,
-                        window.DetailLeft.Size.y)
-                    if window.StatWheelEnabled then
-                        for key, value in pairs(window.DetailStats) do
-                            ScaleformUI.Scaleforms._ui:CallFunction("ADD_STATS_DETAILS_WINDOW_STATWHEEL",
-                                w_id - 1, value.Percentage, value.HudColor)
-                        end
-                    end
-                end
-            end
-        end
-        local timer = GlobalGameTimer
-        if #self.Items == 0 then
-            while #self.Items == 0 do
-                Citizen.Wait(0)
-                if GlobalGameTimer - timer > 150 then
-                    ScaleformUI.Scaleforms._ui:CallFunction("SET_CURRENT_ITEM", 0)
-                    assert(#self.Items ~= 0, "ScaleformUI cannot build a menu with no items")
-                    return
-                end
-            end
-        end
-    end
 
-    local max = self.Pagination:ItemsPerPage()
-    if #self.Items < max then
-        max = #self.Items
-    end
-    self.Pagination:MinItem(self.Pagination:CurrentPageStartIndex())
-
-    if self.scrollingType == MenuScrollingType.CLASSIC and self.Pagination:TotalPages() > 1 then
-        local missingItems = self.Pagination:GetMissingItems()
-        if missingItems > 0 then
-            self.Pagination:ScaleformIndex(self.Pagination:GetPageIndexFromMenuIndex(self.Pagination:CurrentPageEndIndex()) + missingItems - 1)
-            self.Pagination.minItem = self.Pagination:CurrentPageStartIndex() - missingItems
-        end
-    end
-
-    self.Pagination:MaxItem(self.Pagination:CurrentPageEndIndex())
-
-    for i = 1, max, 1 do
-        if (not self:Visible()) then return end
-        self:_itemCreation(self.Pagination:CurrentPage(), i, false, true)
-    end
-
-    self.Pagination:ScaleformIndex(self.Pagination:GetScaleformIndex(self:CurrentSelection()))
-    self.Items[self:CurrentSelection()]:Selected(true)
-
-    AddTextEntry("UIMenu_Current_Description", self:CurrentItem():Description());
-    ScaleformUI.Scaleforms._ui:CallFunction("SET_CURRENT_ITEM",
-        self.Pagination:GetScaleformIndex(self.Pagination:CurrentMenuIndex()))
-    ScaleformUI.Scaleforms._ui:CallFunction("SET_COUNTER_QTTY", self:CurrentSelection(), #self.Items)
-
-    local Item = self.Items[self:CurrentSelection()]
-    local _, subtype = Item()
-    if subtype == "UIMenuSeparatorItem" then
-        if (self.Items[self:CurrentSelection()].Jumpable) then
-            self:GoDown()
-        end
-    end
-    ScaleformUI.Scaleforms._ui:CallFunction("ENABLE_MOUSE", self.Settings.MouseControlsEnabled)
-    ScaleformUI.Scaleforms._ui:CallFunction("ENABLE_3D_ANIMATIONS", self.enabled3DAnimations)
-    self:AnimationEnabled(self:AnimationEnabled())
-    self:FadeInMenu()
-    self._isBuilding = false
+    ScaleformUI.Scaleforms._ui:CallFunction("SET_MENU_DATA", self._Title, subtitle, self.Position.x, self.Position.y,
+        self.AlternativeTitle, self.TxtDictionary, self.TxtName, self:MaxItemsOnScreen(), #self.Items, self.counterColor,
+        self.descFont.FontName, self.descFont.FontID, self.bannerColor:ToArgb(), false, "", "", "", self.menuAlignment, skipViewInitialization)
 end
 
-function UIMenu:_itemCreation(page, pageIndex, before, overflow)
-    local menuIndex = self.Pagination:GetMenuIndexFromPageIndex(page, pageIndex)
-    if not before then
-        if self.Pagination:GetPageItemsCount(page) < self.Pagination:ItemsPerPage() and self.Pagination:TotalPages() > 1 then
-            if self.scrollingType == MenuScrollingType.ENDLESS then
-                if menuIndex > #self.Items then
-                    menuIndex = menuIndex - #self.Items
-                    self.Pagination:MaxItem(menuIndex)
+function UIMenu:SetWindows(update)
+    if update == nil then update = false end
+    if #self.Windows == 0 then
+        ScaleformUI.Scaleforms._ui:CallFunction("SET_WINDOWS_SLOT_DATA_EMPTY")
+        return
+    end
+    local str = "UPDATE_WINDOWS_SLOT_DATA"
+    if not update then
+        ScaleformUI.Scaleforms._ui:CallFunction("SET_WINDOWS_SLOT_DATA_EMPTY")
+        str = "SET_WINDOWS_SLOT_DATA"
+    end
+
+    for w_id, window in pairs(self.Windows) do
+        local Type, SubType = window()
+        if SubType == "UIMenuHeritageWindow" then
+            ScaleformUI.Scaleforms._ui:CallFunction(str, w_id - 1, window.id, window.Mom, window.Dad)
+        elseif SubType == "UIMenuDetailsWindow" then
+            ScaleformUI.Scaleforms._ui:CallFunction(str, w_id - 1, window.id, window.DetailBottom,
+                window.DetailMid, window.DetailTop, window.DetailLeft.Txd, window.DetailLeft.Txn,
+                window.DetailLeft.Pos.x, window.DetailLeft.Pos.y, window.DetailLeft.Size.x,
+                window.DetailLeft.Size.y)
+            if window.StatWheelEnabled then
+                for key, value in pairs(window.DetailStats) do
+                    ScaleformUI.Scaleforms._ui:CallFunction("SET_WINDOWS_SLOT_EXTRA_DATA", w_id - 1, key - 1,
+                        value.Percentage, value.HudColor)
                 end
-            elseif self.scrollingType == MenuScrollingType.CLASSIC and overflow then
-                local missingItems = self.Pagination:ItemsPerPage() - self.Pagination:GetPageItemsCount(page)
-                menuIndex = menuIndex - missingItems
-            elseif self.scrollingType == MenuScrollingType.PAGINATED then
-                if menuIndex > #self.Items then return end
             end
         end
     end
-
-    local scaleformIndex = self.Pagination:GetScaleformIndex(menuIndex)
-
-    local item = self.Items[menuIndex]
-    local Type, SubType = item()
-    BeginScaleformMovieMethod(ScaleformUI.Scaleforms._ui.handle, "ADD_ITEM")
-    PushScaleformMovieFunctionParameterBool(before)
-    PushScaleformMovieFunctionParameterInt(item.ItemId)
-    PushScaleformMovieFunctionParameterInt(menuIndex)
-    if SubType ~= "UIMenuItem" then
-        PushScaleformMovieMethodParameterString(item.Base._formatLeftLabel)
-    else
-        PushScaleformMovieMethodParameterString(item._formatLeftLabel)
+    if not update then
+        ScaleformUI.Scaleforms._ui:CallFunction("SHOW_WINDOWS")
     end
+end
+
+function UIMenu:SendItems()
+    ScaleformUI.Scaleforms._ui:CallFunction("SET_DATA_SLOT_EMPTY")
+    for k,v in pairs(self.Items) do
+        self:SendItemToScaleform(k, false)
+        if self._visibleItems < self:MaxItemsOnScreen() then
+            self._visibleItems = self._visibleItems + 1
+        end
+    end
+end
+
+function UIMenu:SendSidePanelToScaleform(i, update)
+    if update == nil then update = false end
+    local index = i - self.topEdge
+    local item = self.Items[i]
+    if (item.SidePanel == nil or not item.Enabled or index < 0 or index > self:MaxItemsOnScreen()) then
+        ScaleformUI.Scaleforms._ui:CallFunction("SET_SIDE_PANEL_DATA_SLOT_EMPTY")
+        return
+    end
+
+    if not update then
+        ScaleformUI.Scaleforms._ui:CallFunction("SET_SIDE_PANEL_DATA_SLOT_EMPTY")
+    end
+    local str = "UPDATE_SIDE_PANEL_DATA_SLOT"
+    if not update then
+        str = "SET_SIDE_PANEL_DATA_SLOT"
+    end
+
+    if item.SidePanel() == "UIMissionDetailsPanel" then
+        ScaleformUI.Scaleforms._ui:CallFunction(str, index - 1, 0,
+            item.SidePanel.PanelSide, item.SidePanel.TitleType, item.SidePanel.Title,
+            item.SidePanel.TitleColor,
+            item.SidePanel.TextureDict, item.SidePanel.TextureName)
+        for key, value in pairs(item.SidePanel.Items) do
+            ScaleformUI.Scaleforms._ui:CallFunction("SET_SIDE_PANEL_SLOT", index - 1,
+                value.Type, value.TextLeft, value.TextRight, value.Icon, value.IconColor, value.Tick,
+                value._labelFont.FontName, value._labelFont.FontID,
+                value._rightLabelFont.FontName, value._rightLabelFont.FontID)
+        end
+    elseif item.SidePanel() == "UIVehicleColorPickerPanel" then
+        ScaleformUI.Scaleforms._ui:CallFunction(str, index - 1, 1,
+            item.SidePanel.PanelSide, item.SidePanel.TitleType, item.SidePanel.Title,
+            item.SidePanel.TitleColor)
+    end
+    ScaleformUI.Scaleforms._ui:CallFunction("SHOW_SIDE_PANEL")
+end
+
+function UIMenu:SendPanelsToItemScaleform(i, update)
+    if update == nil then update = false end
+    local index = i - self.topEdge
+    local item = self.Items[i]
+
+    if (item.Panels.Count == 0 or not item.Enabled or index < 0 or index > self:MaxItemsOnScreen()) then
+        ScaleformUI.Scaleforms._ui:CallFunction("SET_PANEL_DATA_SLOT_EMPTY")
+        return
+    end
+    local str = "UPDATE_PANEL_DATA_SLOT"
+    if (not update) then
+        ScaleformUI.Scaleforms._ui:CallFunction("SET_PANEL_DATA_SLOT_EMPTY")
+        str = "SET_PANEL_DATA_SLOT"
+    end
+    for pan, panel in pairs(item.Panels) do
+        local pType, pSubType = panel()
+        if pSubType == "UIMenuColorPanel" then
+            if panel.CustomColors ~= nil then
+                local colors = {}
+                for l, m in pairs(panel.CustomColors) do
+                    table.insert(colors, m:ToArgb())
+                end
+                ScaleformUI.Scaleforms._ui:CallFunction(str, index - 1, pan - 1, 0, panel.Title,
+                    panel.ColorPanelColorType, panel.value, table.concat(colors, ","))
+            else
+                ScaleformUI.Scaleforms._ui:CallFunction(str, index - 1, pan - 1, 0, panel.Title,
+                    panel.ColorPanelColorType, panel.value)
+            end
+        elseif pSubType == "UIMenuPercentagePanel" then
+            ScaleformUI.Scaleforms._ui:CallFunction(str, index - 1, pan - 1, 1, panel.Title, panel.Min,
+                panel.Max, panel._percentage)
+        elseif pSubType == "UIMenuGridPanel" then
+            ScaleformUI.Scaleforms._ui:CallFunction(str, index - 1, pan - 1, 2, panel.TopLabel,
+                panel.RightLabel, panel.LeftLabel, panel.BottomLabel, panel._CirclePosition.x,
+                panel._CirclePosition.y, true, panel.GridType)
+            elseif pSubType == "UIMenuStatisticsPanel" then
+                local arr = {}
+                for k,v in pairs(panel.Items) do
+                    table.insert(arr, v['name'] ..":".. v['value'])
+                end
+                ScaleformUI.Scaleforms._ui:CallFunction(str, index - 1, pan - 1, 3, table.concat(arr, ","))
+            elseif pSubType == "UIMenuVehicleColourPickerPanel" then
+            ScaleformUI.Scaleforms._ui:CallFunction(str, index - 1, pan - 1, 4)
+        end
+    end
+    ScaleformUI.Scaleforms._ui:CallFunction("SHOW_PANELS")
+end
+
+function UIMenu:SendItemToScaleform(i, update)
+    if update == nil then update = false end
+    local item = self.Items[i]
+    local str = "UPDATE_DATA_SLOT"
+    if not update then
+        str = "SET_DATA_SLOT"
+    end
+    local Type, SubType = item()
+    local it = item
+    if SubType ~= "UIMenuItem" then
+        it = item.Base
+    end
+
+    BeginScaleformMovieMethod(ScaleformUI.Scaleforms._ui.handle, str)
+    PushScaleformMovieFunctionParameterInt(i - 1)
+    PushScaleformMovieFunctionParameterInt(item.ItemId)
+    PushScaleformMovieMethodParameterString(it._formatLeftLabel)
     PushScaleformMovieFunctionParameterBool(item:Enabled())
     PushScaleformMovieFunctionParameterBool(item:BlinkDescription())
-
-    if SubType == "UIMenuDynamicListItem" then -- dynamic list item are handled like list items in the scaleform.. so the type remains 1
-        local str = item:createListString()
-        PushScaleformMovieMethodParameterString(str)
+    if SubType == "UIMenuDynamicListItem" or SubType == "UIMenuListItem" then -- dynamic list item are handled like list items in the scaleform.. so the type remains 1
+        local lbl = item:createListString()
+        PushScaleformMovieMethodParameterString(lbl)
         PushScaleformMovieFunctionParameterInt(0)
-        PushScaleformMovieFunctionParameterInt(item.Base._mainColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._textColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightedTextColor:ToArgb())
-        EndScaleformMovieMethod()
-    elseif SubType == "UIMenuListItem" then
-        AddTextEntry("listitem_" .. menuIndex .. "_list", item:createListString())
-        BeginTextCommandScaleformString("listitem_" .. menuIndex .. "_list")
-        EndTextCommandScaleformString()
-        PushScaleformMovieFunctionParameterInt(item:Index() - 1)
-        PushScaleformMovieFunctionParameterInt(item.Base._mainColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._textColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightedTextColor:ToArgb())
-        EndScaleformMovieMethod()
+        PushScaleformMovieFunctionParameterInt(item:MainColor():ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:HighlightColor():ToArgb())
     elseif SubType == "UIMenuCheckboxItem" then
         PushScaleformMovieFunctionParameterInt(item.CheckBoxStyle)
-        PushScaleformMovieFunctionParameterBool(item._Checked)
-        PushScaleformMovieFunctionParameterInt(item.Base._mainColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._textColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightedTextColor:ToArgb())
-        EndScaleformMovieMethod()
+        PushScaleformMovieFunctionParameterBool(item:Checked())
+        PushScaleformMovieFunctionParameterInt(item:MainColor():ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:HighlightColor():ToArgb())
     elseif SubType == "UIMenuSliderItem" then
         PushScaleformMovieFunctionParameterInt(item._Max)
         PushScaleformMovieFunctionParameterInt(item._Multiplier)
         PushScaleformMovieFunctionParameterInt(item:Index())
-        PushScaleformMovieFunctionParameterInt(item.Base._mainColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._textColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightedTextColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.SliderColor:ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:MainColor():ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:HighlightColor():ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:SliderColor():ToArgb())
         PushScaleformMovieFunctionParameterBool(item._heritage)
-        EndScaleformMovieMethod()
     elseif SubType == "UIMenuProgressItem" then
         PushScaleformMovieFunctionParameterInt(item._Max)
         PushScaleformMovieFunctionParameterInt(item._Multiplier)
         PushScaleformMovieFunctionParameterInt(item:Index())
-        PushScaleformMovieFunctionParameterInt(item.Base._mainColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._textColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightedTextColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.SliderColor:ToArgb())
-        EndScaleformMovieMethod()
+        PushScaleformMovieFunctionParameterInt(item:MainColor():ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:HighlightColor():ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:SliderColor():ToArgb())
     elseif SubType == "UIMenuStatsItem" then
         PushScaleformMovieFunctionParameterInt(item:Index())
         PushScaleformMovieFunctionParameterInt(item._Type)
-        PushScaleformMovieFunctionParameterInt(item._Color)
-        PushScaleformMovieFunctionParameterInt(item.Base._mainColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._textColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightedTextColor:ToArgb())
-        EndScaleformMovieMethod()
+        PushScaleformMovieFunctionParameterInt(item:SliderColor())
+        PushScaleformMovieFunctionParameterInt(item:MainColor():ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:HighlightColor():ToArgb())
     elseif SubType == "UIMenuSeparatorItem" then
         PushScaleformMovieFunctionParameterBool(item.Jumpable)
-        PushScaleformMovieFunctionParameterInt(item.Base._mainColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._textColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item.Base._highlightedTextColor:ToArgb())
-        EndScaleformMovieMethod()
+        PushScaleformMovieFunctionParameterInt(item:MainColor():ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:HighlightColor():ToArgb())
     else
-        PushScaleformMovieFunctionParameterInt(item._mainColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item._highlightColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item._textColor:ToArgb())
-        PushScaleformMovieFunctionParameterInt(item._highlightedTextColor:ToArgb())
-        EndScaleformMovieMethod()
-        ScaleformUI.Scaleforms._ui:CallFunction("SET_RIGHT_LABEL", scaleformIndex, item._formatRightLabel)
-        if item._rightBadge ~= BadgeStyle.NONE then
-            if item._rightBadge == -1 then
-                ScaleformUI.Scaleforms._ui:CallFunction("SET_CUSTOM_RIGHT_BADGE", scaleformIndex, item.customRightIcon.TXD, item.customRightIcon.TXN)
-            else
-                ScaleformUI.Scaleforms._ui:CallFunction("SET_RIGHT_BADGE", scaleformIndex, item._rightBadge)
-            end
-        end
+        PushScaleformMovieFunctionParameterInt(item:MainColor():ToArgb())
+        PushScaleformMovieFunctionParameterInt(item:HighlightColor():ToArgb())
     end
 
-    if SubType ~= "UIMenuItem" then
-        ScaleformUI.Scaleforms._ui:CallFunction("SET_ITEM_LABEL_FONT", scaleformIndex,
-            item.Base._labelFont.FontName, item.Base._labelFont.FontID)
-        ScaleformUI.Scaleforms._ui:CallFunction("SET_ITEM_RIGHT_LABEL_FONT", scaleformIndex,
-            item.Base._rightLabelFont.FontName, item.Base._rightLabelFont.FontID)
-        if item.Base._leftBadge ~= BadgeStyle.NONE then
-            if item.Base._leftBadge == -1 then
-                ScaleformUI.Scaleforms._ui:CallFunction("SET_CUSTOM_LEFT_BADGE", scaleformIndex, item.Base.customLeftIcon.TXD, item.Base.customLeftIcon.TXN)
-            else
-                ScaleformUI.Scaleforms._ui:CallFunction("SET_LEFT_BADGE", scaleformIndex, item.Base._leftBadge)
-            end
-        end
-    else
-        ScaleformUI.Scaleforms._ui:CallFunction("SET_ITEM_LABEL_FONT", scaleformIndex, item._labelFont.FontName,
-            item._labelFont.FontID)
-        ScaleformUI.Scaleforms._ui:CallFunction("SET_ITEM_RIGHT_LABEL_FONT", scaleformIndex,
-            item._rightLabelFont.FontName, item._rightLabelFont.FontID)
-        if item._leftBadge ~= BadgeStyle.NONE then
-            if item._leftBadge == -1 then
-                ScaleformUI.Scaleforms._ui:CallFunction("SET_CUSTOM_LEFT_BADGE", scaleformIndex, item.customLeftIcon.TXD, item.customLeftIcon.TXN)
-            else
-                ScaleformUI.Scaleforms._ui:CallFunction("SET_LEFT_BADGE", scaleformIndex, item._leftBadge)
-            end
-        end
-    end
-    if item.SidePanel ~= nil then
-        if item.SidePanel() == "UIMissionDetailsPanel" then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM", scaleformIndex, 0,
-                item.SidePanel.PanelSide, item.SidePanel.TitleType, item.SidePanel.Title,
-                item.SidePanel.TitleColor,
-                item.SidePanel.TextureDict, item.SidePanel.TextureName)
-            for key, value in pairs(item.SidePanel.Items) do
-                ScaleformUI.Scaleforms._ui:CallFunction("ADD_MISSION_DETAILS_DESC_ITEM", scaleformIndex,
-                    value.Type, value.TextLeft, value.TextRight, value.Icon, value.IconColor, value.Tick,
-                    value._labelFont.FontName, value._labelFont.FontID,
-                    value._rightLabelFont.FontName, value._rightLabelFont.FontID)
-            end
-        elseif item.SidePanel() == "UIVehicleColorPickerPanel" then
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_SIDE_PANEL_TO_ITEM", scaleformIndex, 1,
-                item.SidePanel.PanelSide, item.SidePanel.TitleType, item.SidePanel.Title,
-                item.SidePanel.TitleColor)
-        end
-    end
-    if #item.Panels > 0 then
-        for pan, panel in pairs(item.Panels) do
-            local pType, pSubType = panel()
-            if pSubType == "UIMenuColorPanel" then
-                if panel.CustomColors ~= nil then
-                    local colors = {}
-                    for l, m in pairs(panel.CustomColors) do
-                        table.insert(colors, m:ToArgb())
-                    end
-                    ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", scaleformIndex, 0, panel.Title,
-                        panel.ColorPanelColorType, panel.value, table.concat(colors, ","))
-                else
-                    ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", scaleformIndex, 0, panel.Title,
-                        panel.ColorPanelColorType, panel.value)
-                end
-            elseif pSubType == "UIMenuPercentagePanel" then
-                ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", scaleformIndex, 1, panel.Title, panel.Min,
-                    panel.Max, panel._percentage)
-            elseif pSubType == "UIMenuGridPanel" then
-                ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", scaleformIndex, 2, panel.TopLabel,
-                    panel.RightLabel, panel.LeftLabel, panel.BottomLabel, panel._CirclePosition.x,
-                    panel._CirclePosition.y, true, panel.GridType)
-            elseif pSubType == "UIMenuStatisticsPanel" then
-                ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", scaleformIndex, 3)
-                if #panel.Items then
-                    for key, stat in pairs(panel.Items) do
-                        ScaleformUI.Scaleforms._ui:CallFunction("ADD_STATISTIC_TO_PANEL", scaleformIndex, pan - 1, stat['name'], stat['value'])
-                    end
-                end
-            elseif pSubType == "UIMenuVehicleColourPickerPanel" then
-                ScaleformUI.Scaleforms._ui:CallFunction("ADD_PANEL", scaleformIndex, 4)
-            end
-        end
-    end
+    PushScaleformMovieMethodParameterString(it._formatRightLabel)
+    PushScaleformMovieFunctionParameterInt(it._leftBadge)
+    PushScaleformMovieMethodParameterString(it.customLeftIcon.TXD)
+    PushScaleformMovieMethodParameterString(it.customLeftIcon.TXN)
+    PushScaleformMovieFunctionParameterInt(it._rightBadge)
+    PushScaleformMovieMethodParameterString(it.customRightIcon.TXD)
+    PushScaleformMovieMethodParameterString(it.customRightIcon.TXN)
+    PushScaleformMovieMethodParameterString(it._labelFont.FontName)
+    PushScaleformMovieMethodParameterString(it._rightLabelFont.FontName)
+    EndScaleformMovieMethod()
 end
 
 function UIMenu:FilterMenuItems(predicate, fail)
     assert(not self._itemless, "ScaleformUI - You can't compare or sort an itemless menu")
-    self.Items[self:CurrentSelection()]:Selected(false)
+    self:CurrentItem():Selected(false)
     if self._unfilteredMenuItems == nil or #self._unfilteredMenuItems == 0 then
         self._unfilteredMenuItems = self.Items
     end
@@ -1232,18 +985,16 @@ function UIMenu:FilterMenuItems(predicate, fail)
     if #self.Items == 0 then
         self:Clear()
         self.Items = self._unfilteredMenuItems
-        self.Pagination:TotalItems(#self.Items)
         self:BuildUpMenuAsync(true)
         fail()
         return
     end
-    self.Pagination:TotalItems(#self.Items)
     self:BuildUpMenuAsync(true)
 end
 
 function UIMenu:SortMenuItems(compare)
     assert(not self._itemless, "ScaleformUI - You can't compare or sort an itemless menu")
-    self.Items[self:CurrentSelection()]:Selected(false)
+    self:CurrentItem():Selected(false)
     if self._unfilteredMenuItems == nil or #self._unfilteredMenuItems == 0 then
         self._unfilteredMenuItems = self.Items
     end
@@ -1251,17 +1002,15 @@ function UIMenu:SortMenuItems(compare)
     local list = self._unfilteredMenuItems
     table.sort(list, compare)
     self.Items = list
-    self.Pagination:TotalItems(#self.Items)
     self:BuildUpMenuAsync(true)
 end
 
 function UIMenu:ResetFilter()
     assert(not self._itemless, "ScaleformUI - You can't compare or sort an itemless menu")
     if self._unfilteredMenuItems ~= nil and #self._unfilteredMenuItems > 0 then
-        self.Items[self:CurrentSelection()]:Selected(false)
+        self:CurrentItem():Selected(false)
         self:Clear()
         self.Items = self._unfilteredMenuItems
-        self.Pagination:TotalItems(#self.Items)
         self:BuildUpMenuAsync(true)
     end
 end
@@ -1367,32 +1116,32 @@ function UIMenu:ProcessControl()
         end
     end
 
-    if IsDisabledControlJustPressed(0, 10) then
-        local index = self:CurrentSelection() - self.Pagination:ItemsPerPage()
-        if index < 0 then
-            local pagIndex = self.Pagination:GetPageIndexFromMenuIndex(self:CurrentSelection())
-            local newPage = self.Pagination:TotalPages()
-            index = self.Pagination:GetMenuIndexFromPageIndex(newPage, pageIndex)
-            local menuMaxItem = #self.Items
-            if index > menuMaxItem then
-                index = menuMaxItem
-            end
-        end
-        self:CurrentSelection(index)
-        self.OnIndexChange(self, self:CurrentSelection())
-    end
-    if IsDisabledControlJustPressed(0, 11) then
-        local index = self:CurrentSelection() + self.Pagination:ItemsPerPage()
-        if index >= #self.Items and self.Pagination:CurrentPage() < self.Pagination:TotalPages() then
-            index = #self.Items
-        elseif index >= #self.Items and self.Pagination:CurrentPage() == self.Pagination:TotalPages() then
-            local pagIndex = self.Pagination:GetPageIndexFromMenuIndex(self:CurrentSelection())
-            local newPage = 0
-            index = self.Pagination:GetMenuIndexFromPageIndex(newPage, pagIndex)
-        end
-        self:CurrentSelection(index)
-        self.OnIndexChange(self, self:CurrentSelection())
-    end
+    -- if IsDisabledControlJustPressed(0, 10) then
+    --     local index = self:CurrentSelection() - self.Pagination:ItemsPerPage()
+    --     if index < 0 then
+    --         local pagIndex = self.Pagination:GetPageIndexFromMenuIndex(self:CurrentSelection())
+    --         local newPage = self.Pagination:TotalPages()
+    --         index = self.Pagination:GetMenuIndexFromPageIndex(newPage, pageIndex)
+    --         local menuMaxItem = #self.Items
+    --         if index > menuMaxItem then
+    --             index = menuMaxItem
+    --         end
+    --     end
+    --     self:CurrentSelection(index)
+    --     self.OnIndexChange(self, self:CurrentSelection())
+    -- end
+    -- if IsDisabledControlJustPressed(0, 11) then
+    --     local index = self:CurrentSelection() + self.Pagination:ItemsPerPage()
+    --     if index >= #self.Items and self.Pagination:CurrentPage() < self.Pagination:TotalPages() then
+    --         index = #self.Items
+    --     elseif index >= #self.Items and self.Pagination:CurrentPage() == self.Pagination:TotalPages() then
+    --         local pagIndex = self.Pagination:GetPageIndexFromMenuIndex(self:CurrentSelection())
+    --         local newPage = 0
+    --         index = self.Pagination:GetMenuIndexFromPageIndex(newPage, pagIndex)
+    --     end
+    --     self:CurrentSelection(index)
+    --     self.OnIndexChange(self, self:CurrentSelection())
+    -- end
 
     if self.Controls.Select.Enabled and ((IsDisabledControlJustPressed(0, 201) or IsDisabledControlJustPressed(1, 201) or IsDisabledControlJustPressed(2, 201)) or (self.leftClickEnabled and IsDisabledControlJustPressed(0, 24))) then
         Citizen.CreateThread(function()
@@ -1424,84 +1173,58 @@ function UIMenu:ButtonDelay()
 end
 
 function UIMenu:CurrentItem()
-    return self.Items[self:CurrentSelection()]
+    return self.Items[self._currentSelection]
 end
 
 ---GoUp
 function UIMenu:GoUp()
-    self.Items[self:CurrentSelection()]:Selected(false)
+    self:CurrentItem():Selected(false)
     repeat
         Citizen.Wait(0)
-        local overflow = self:CurrentSelection() == 1 and self.Pagination:TotalPages() > 1
-        if self.Pagination:GoUp() then
-            if self.scrollingType == MenuScrollingType.ENDLESS or (self.scrollingType == MenuScrollingType.CLASSIC and not overflow) then
-                self:_itemCreation(self.Pagination:GetPage(self:CurrentSelection()), self.Pagination:CurrentPageIndex(),
-                    true, false)
-                ScaleformUI.Scaleforms._ui:CallFunction("SET_INPUT_EVENT", 8, self._delay) --[[@as number]]
-            elseif self.scrollingType == MenuScrollingType.PAGINATED or (self.scrollingType == MenuScrollingType.CLASSIC and overflow) then
-                self._isBuilding = true
-                self:FadeOutItems()
-                self.isFading = true
-                ScaleformUI.Scaleforms._ui:CallFunction("CLEAR_ITEMS")
-                local max = self.Pagination:ItemsPerPage()
-                for i = 1, max, 1 do
-                    if (not self:Visible()) then return end
-                    self:_itemCreation(self.Pagination:CurrentPage(), i, false, true)
-                end
-                self._isBuilding = false
-            end
+        self._currentSelection = self._currentSelection - 1
+        if self._currentSelection < self.topEdge then
+            self.topEdge = self.topEdge - 1
         end
-    until self.Items[self:CurrentSelection()].ItemId ~= 6 or (self.Items[self:CurrentSelection()].ItemId == 6 and not self.Items[self:CurrentSelection()].Jumpable)
+        if self._currentSelection < 1 then
+            self._currentSelection = #self.Items
+            self.topEdge = #self.Items - self._visibleItems + 1
+        end
+    until self:CurrentItem().ItemId ~= 6 or (self:CurrentItem().ItemId == 6 and not self:CurrentItem().Jumpable)
+    ScaleformUI.Scaleforms._ui:CallFunction("SET_INPUT_EVENT", 8)
     PlaySoundFrontend(-1, self.Settings.Audio.UpDown, self.Settings.Audio.Library, true)
-    AddTextEntry("UIMenu_Current_Description", self:CurrentItem():Description());
-    ScaleformUI.Scaleforms._ui:CallFunction("SET_CURRENT_ITEM", self.Pagination:ScaleformIndex())
-    ScaleformUI.Scaleforms._ui:CallFunction("SET_COUNTER_QTTY", self:CurrentSelection(), #self.Items)
-    self.Items[self:CurrentSelection()]:Selected(true)
-    if self.isFading then
-        self:FadeInItems()
-    end
+    AddTextEntry("UIMenu_Current_Description", self:CurrentItem():Description())
+    self:SendPanelsToItemScaleform(self._currentSelection)
+    self:SendSidePanelToScaleform(self._currentSelection)
+    self:CurrentItem():Selected(true)
     self.OnIndexChange(self, self:CurrentSelection())
 end
 
 ---GoDown
 function UIMenu:GoDown()
-    self.Items[self:CurrentSelection()]:Selected(false)
+    self:CurrentItem():Selected(false)
     repeat
         Citizen.Wait(0)
-        local overflow = self:CurrentSelection() == #self.Items and self.Pagination:TotalPages() > 1
-        if self.Pagination:GoDown() then
-            if self.scrollingType == MenuScrollingType.ENDLESS or (self.scrollingType == MenuScrollingType.CLASSIC and not overflow) then
-                self:_itemCreation(self.Pagination:GetPage(self:CurrentSelection()), self.Pagination:CurrentPageIndex(),
-                    false, overflow)
-                ScaleformUI.Scaleforms._ui:CallFunction("SET_INPUT_EVENT", 9, self._delay) --[[@as number]]
-            elseif self.scrollingType == MenuScrollingType.PAGINATED or (self.scrollingType == MenuScrollingType.CLASSIC and overflow) then
-                self._isBuilding = true
-                self:FadeOutItems()
-                self.isFading = true
-                ScaleformUI.Scaleforms._ui:CallFunction("CLEAR_ITEMS")
-                local max = self.Pagination:ItemsPerPage()
-                for i = 1, max, 1 do
-                    if (not self:Visible()) then return end
-                    self:_itemCreation(self.Pagination:CurrentPage(), i, false, true)
-                end
-                self._isBuilding = false
-            end
+        self._currentSelection = self._currentSelection + 1
+        if self._currentSelection >= self.topEdge + self._visibleItems then
+            self.topEdge = self.topEdge + 1
         end
-    until self.Items[self:CurrentSelection()].ItemId ~= 6 or (self.Items[self:CurrentSelection()].ItemId == 6 and not self.Items[self:CurrentSelection()].Jumpable)
+        if self._currentSelection > #self.Items then
+            self._currentSelection = 1
+            self.topEdge = 1
+        end
+    until self:CurrentItem().ItemId ~= 6 or (self:CurrentItem().ItemId == 6 and not self:CurrentItem().Jumpable)
+    ScaleformUI.Scaleforms._ui:CallFunction("SET_INPUT_EVENT", 9)
     PlaySoundFrontend(-1, self.Settings.Audio.UpDown, self.Settings.Audio.Library, true)
-    AddTextEntry("UIMenu_Current_Description", self:CurrentItem():Description());
-    ScaleformUI.Scaleforms._ui:CallFunction("SET_CURRENT_ITEM", self.Pagination:ScaleformIndex())
-    ScaleformUI.Scaleforms._ui:CallFunction("SET_COUNTER_QTTY", self:CurrentSelection(), #self.Items)
-    self.Items[self:CurrentSelection()]:Selected(true)
-    if self.isFading then
-        self:FadeInItems()
-    end
+    AddTextEntry("UIMenu_Current_Description", self:CurrentItem():Description())
+    self:SendPanelsToItemScaleform(self._currentSelection)
+    self:SendSidePanelToScaleform(self._currentSelection)
+    self:CurrentItem():Selected(true)
     self.OnIndexChange(self, self:CurrentSelection())
 end
 
 ---GoLeft
 function UIMenu:GoLeft()
-    local Item = self.Items[self:CurrentSelection()]
+    local Item = self:CurrentItem()
     local type, subtype = Item()
     if subtype ~= "UIMenuListItem" and subtype ~= "UIMenuDynamicListItem" and subtype ~= "UIMenuSliderItem" and subtype ~= "UIMenuProgressItem" and subtype ~= "UIMenuStatsItem" then
         return
@@ -1511,38 +1234,32 @@ function UIMenu:GoLeft()
         PlaySoundFrontend(-1, self.Settings.Audio.Error, self.Settings.Audio.Library, true)
         return
     end
-
-    local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnInt("SET_INPUT_EVENT", 10)
-
     if subtype == "UIMenuListItem" then
-        Item:Index(res + 1)
+        Item:Index(Item:Index() - 1)
         self.OnListChange(self, Item, Item._Index)
         Item.OnListChanged(self, Item, Item._Index)
-        PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
     elseif (subtype == "UIMenuDynamicListItem") then
         local result = tostring(Item.Callback(Item, "left"))
         Item:CurrentListItem(result)
-        PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
     elseif subtype == "UIMenuSliderItem" then
-        Item:Index(res)
+        Item:Index(Item:Index() - 1)
         self.OnSliderChange(self, Item, Item:Index())
         Item.OnSliderChanged(self, Item, Item._Index)
-        PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
     elseif subtype == "UIMenuProgressItem" then
-        Item:Index(res)
+        Item:Index(Item:Index() - 1)
         self.OnProgressChange(self, Item, Item:Index())
         Item.OnProgressChanged(self, Item, Item:Index())
-        PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
     elseif subtype == "UIMenuStatsItem" then
-        Item:Index(res)
+        Item:Index(Item:Index() - 1)
         self.OnStatsChanged(self, Item, Item:Index())
         Item.OnStatsChanged(self, Item, Item._Index)
     end
+    PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
 end
 
 ---GoRight
 function UIMenu:GoRight()
-    local Item = self.Items[self:CurrentSelection()]
+    local Item = self:CurrentItem()
     local type, subtype = Item()
     if subtype ~= "UIMenuListItem" and subtype ~= "UIMenuDynamicListItem" and subtype ~= "UIMenuSliderItem" and subtype ~= "UIMenuProgressItem" and subtype ~= "UIMenuStatsItem" then
         return
@@ -1551,39 +1268,33 @@ function UIMenu:GoRight()
         PlaySoundFrontend(-1, self.Settings.Audio.Error, self.Settings.Audio.Library, true)
         return
     end
-
-    local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnInt("SET_INPUT_EVENT", 11)
-
     if subtype == "UIMenuListItem" then
-        Item:Index(res + 1)
+        Item:Index(Item:Index() + 1)
         self.OnListChange(self, Item, Item._Index)
         Item.OnListChanged(self, Item, Item._Index)
-        PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
     elseif (subtype == "UIMenuDynamicListItem") then
         local result = tostring(Item.Callback(Item, "right"))
         Item:CurrentListItem(result)
-        PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
     elseif subtype == "UIMenuSliderItem" then
-        Item:Index(res)
+        Item:Index(Item:Index() + 1)
         self.OnSliderChange(self, Item, Item:Index())
         Item.OnSliderChanged(self, Item, Item._Index)
-        PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
     elseif subtype == "UIMenuProgressItem" then
-        Item:Index(res)
+        Item:Index(Item:Index() + 1)
         self.OnProgressChange(self, Item, Item:Index())
         Item.OnProgressChanged(self, Item, Item:Index())
-        PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
     elseif subtype == "UIMenuStatsItem" then
-        Item:Index(res)
+        Item:Index(Item:Index() + 1)
         self.OnStatsChanged(self, Item, Item:Index())
         Item.OnStatsChanged(self, Item, Item._Index)
     end
+    PlaySoundFrontend(-1, self.Settings.Audio.LeftRight, self.Settings.Audio.Library, true)
 end
 
 ---SelectItem
 ---@param play boolean|nil
 function UIMenu:SelectItem(play)
-    if not self.Items[self:CurrentSelection()]:Enabled() then
+    if not self:CurrentItem():Enabled() then
         PlaySoundFrontend(-1, self.Settings.Audio.Error, self.Settings.Audio.Library, true)
         return
     end
@@ -1591,7 +1302,7 @@ function UIMenu:SelectItem(play)
         PlaySoundFrontend(-1, self.Settings.Audio.Select, self.Settings.Audio.Library, true)
     end
 
-    local Item = self.Items[self:CurrentSelection()]
+    local Item = self:CurrentItem()
     local type, subtype = Item()
     if subtype == "UIMenuCheckboxItem" then
         Item:Checked(not Item:Checked())
@@ -1647,12 +1358,7 @@ function UIMenu:GoBack(boolean, bypass)
             BreadcrumbsHandler:Backwards()
             self:Visible(false)
             if prevMenu ~= nil then
-                if prevMenu.menu() == "UIMenu" then
-                    prevMenu.menu.differentBanner = self.TxtDictionary ~= prevMenu.menu.TxtDictionary and self.TxtName ~= prevMenu.menu.TxtName;
-                    prevMenu.menu:Visible(true)
-                else
-                    prevMenu.menu:Visible(true)
-                end
+                prevMenu.menu:Visible(true)
             end
             BreadcrumbsHandler.SwitchInProgress = false
         end
@@ -1706,7 +1412,7 @@ function UIMenu:Draw()
         local dir = GetFinalRenderedCamRot(2)
         local fvar = Wrap(dir.z, 0, 360)
         if self.fSavedGlareDirection == 0 or (self.fSavedGlareDirection - fvar) > fRotationTolerance or (self.fSavedGlareDirection - fvar) < -fRotationTolerance then
-            self.fSavedGlareDirection = fvar;
+            self.fSavedGlareDirection = fvar
             self._menuGlare:CallFunction("SET_DATA_SLOT", self.fSavedGlareDirection)
         end
         DrawScaleformMovie(self._menuGlare.handle, self._glarePos.x, self._glarePos.y, self._glareSize.w, self._glareSize.h, 255, 255, 255, 255, 0)
@@ -1737,7 +1443,8 @@ function UIMenu:CallExtensionMethod()
 end
 
 function UIMenu:mouseCheck()
-    self._mouseOnMenu = self:MouseControlsEnabled() and ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnBool("IS_MOUSE_ON_MENU");
+    self._mouseOnMenu = self:MouseControlsEnabled() and
+    ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnBool("IS_MOUSE_ON_MENU")
 end
 
 function UIMenu:IsMouseOverTheMenu()
@@ -1778,7 +1485,7 @@ function UIMenu:ProcessMouse()
     if success == 1 then
         if event_type == 5 then  --ON CLICK
             if context == 0 then -- normal menu items
-                local item = self.Items[item_id]
+                local item = self.Items[item_id + 1]
                 if (item == nil) then return end
                 if item:Selected() then
                     if item.ItemId == 0 or item.ItemId == 2 then
@@ -1787,7 +1494,7 @@ function UIMenu:ProcessMouse()
                         Citizen.CreateThread(function()
                             local value = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnInt("SELECT_ITEM", item_id) --[[@as number]]
 
-                            local curr_select_item = self.Items[self:CurrentSelection()]
+                            local curr_select_item = self:CurrentItem()
                             local item_type_curr, item_subtype_curr = curr_select_item()
                             if item.ItemId == 1 then
                                 if curr_select_item:Index() ~= value then
@@ -1822,25 +1529,24 @@ function UIMenu:ProcessMouse()
                     PlaySoundFrontend(-1, "ERROR", "HUD_FRONTEND_DEFAULT_SOUNDSET", true)
                     return
                 end
-                self:CurrentSelection(item_id)
-                ScaleformUI.Scaleforms._ui:CallFunction("SET_COUNTER_QTTY", self:CurrentSelection(), #self.Items)
+                self:CurrentSelection(item_id+1)
                 PlaySoundFrontend(-1, "SELECT", "HUD_FRONTEND_DEFAULT_SOUNDSET", true)
             elseif context == 10 then -- panels (10 => context 1, panel_type 0) // ColorPanel
                 Citizen.CreateThread(function()
-                    local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnString("SELECT_PANEL", self.Pagination:GetScaleformIndex(self.Pagination:CurrentMenuIndex())) --[[@as number]]
-
+                    local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnString("SELECT_PANEL", self._currentSelection - 1) --[[@as number]]
                     local split = Split(res, ",")
-                    local panel = self.Items[self:CurrentSelection()].Panels[tonumber(split[1]) + 1]
+                    local panel = self:CurrentItem().Panels[tonumber(split[1]) + 1]
                     panel.value = tonumber(split[2]) + 1
                     self.OnColorPanelChanged(panel.ParentItem, panel, panel:CurrentSelection())
                     panel.OnColorPanelChanged(panel.ParentItem, panel, panel:CurrentSelection())
                 end)
             elseif context == 14 then
                 Citizen.CreateThread(function()
-                    local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnInt("SELECT_PANEL", CurrentSelection);
-                    local picker = self.Items[self:CurrentSelection()].Panels[res]
+                    local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnInt("SELECT_PANEL", self:CurrentSelection() - 1)
+                    local picker = self:CurrentItem().Panels[res]
                     if item_id ~= -1 then
-                        local colString = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnString("GET_PICKER_COLOR", item_id)
+                        local colString = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnString("GET_PICKER_COLOR",
+                            item_id)
                         local split = Split(colString, ",")
                         picker._value = item_id
                         picker:_pickerSelect(SColor.FromArgb(tonumber(split[1]), tonumber(split[2]), tonumber(split[3])))
@@ -1851,7 +1557,7 @@ function UIMenu:ProcessMouse()
             elseif context == 12 then -- panels (12 => context 1, panel_type 2) // GridPanel
                 cursor_pressed = true
             elseif context == 2 then  -- sidepanel
-                local panel = self.Items[self:CurrentSelection()].SidePanel
+                local panel = self:CurrentItem().SidePanel
                 if item_id ~= -1 then
                     panel.Value = item_id - 1
                     panel.PickerSelect(panel.ParentItem, panel, panel.Value)
@@ -1863,39 +1569,39 @@ function UIMenu:ProcessMouse()
             cursor_pressed = false
             SetMouseCursorSprite(1)
             if (self.mouseReset) then
-                self.mouseReset = false;
+                self.mouseReset = false
             end
         elseif event_type == 8 then -- ON NOT HOVER
             cursor_pressed = false
             if context == 0 then
-                self.Items[item_id]:Hovered(false)
+                self.Items[item_id + 1]:Hovered(false)
             elseif context == 2 then
-                local panel = self.Items[self:CurrentSelection()].SidePanel
+                local panel = self:CurrentItem().SidePanel
                 panel:_PickerRollout()
             elseif context == 14 then
-                local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnInt("SELECT_PANEL", CurrentSelection);
-                local picker = self.Items[self:CurrentSelection()].Panels[res]
-                picker:_PickerRollout();
+                local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnInt("SELECT_PANEL", self:CurrentSelection() - 1)
+                local picker = self:CurrentItem().Panels[res]
+                picker:_PickerRollout()
             end
             if not self:IsMouseOverTheMenu() then
                 return
             end
             SetMouseCursorSprite(1)
             if (self.mouseReset) then
-                self.mouseReset = false;
+                self.mouseReset = false
             end
         elseif event_type == 9 then -- ON HOVERED
             if context == 0 then
-                self.Items[item_id]:Hovered(true)
+                self.Items[item_id + 1]:Hovered(true)
             elseif context == 2 then
-                local panel = self.Items[self:CurrentSelection()].SidePanel
+                local panel = self:CurrentItem().SidePanel
                 if item_id ~= -1 then
                     panel:_PickerHovered(item_id, VehicleColors:GetColorById(item_id))
                 end
             elseif context == 14 then
                 if item_id ~= -1 then
-                    local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnInt("SELECT_PANEL", CurrentSelection);
-                    local picker = self.Items[self:CurrentSelection()].Panels[res]
+                    local res = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnInt("SELECT_PANEL", self:CurrentSelection() - 1)
+                    local picker = self:CurrentItem().Panels[res]
                     picker:_PickerHovered(item_id, VehicleColors:GetColorById(item_id))
                 end
             end
@@ -1920,7 +1626,7 @@ function UIMenu:ProcessMouse()
             local value = ScaleformUI.Scaleforms._ui:CallFunctionAsyncReturnString("SET_INPUT_MOUSE_EVENT_CONTINUE") --[[@as number]]
 
             local split = Split(value, ",")
-            local panel = self.Items[self:CurrentSelection()].Panels[tonumber(split[1]) + 1]
+            local panel = self:CurrentItem().Panels[tonumber(split[1]) + 1]
             local panel_type, panel_subtype = panel()
 
             if panel_subtype == "UIMenuGridPanel" then
@@ -2040,33 +1746,23 @@ function UIMenu:RemoveEnabledControl(Inputgroup, Control, Controller)
     end
 end
 
-function UIMenu:SetMenuOffset(x,y)
-    self.Position = vector2(x,y)
-    local safezone = (1.0 - math.round(GetSafeZoneSize(), 2)) * 100 * 0.005;
-    local rightAlign = self.menuAlignment == MenuAlignment.RIGHT
-    local glareX = 0.585
-    local glareW = 1.35
-    if not GetWideScreen() then
-         glareX = 0.45
-         glareW = 1.0
-    end
-
-    local pos1080 = ConvertScaleformCoordsToResolutionCoords(x,y)
-    local screenCoords = ConvertResolutionCoordsToScreenCoords(pos1080.x,pos1080.y)
-    self._glarePos = vector2(screenCoords.x + glareX + safezone, screenCoords.y + 0.45 + safezone)
-    if rightAlign then
-        local w,h = GetActualScreenResolution()
-        screenCoords = ConvertResolutionCoordsToScreenCoords(w - pos1080.x,pos1080.y)
-        glareX = 0.36
-        if not GetWideScreen() then
-            glareX = 0.225
-        end
-        self._glarePos = vector2(screenCoords.x + glareX - safezone, screenCoords.y + 0.45 + safezone)
-    end
-
-    self._glareSize = {w=glareW, h=1.0}
-        
+function UIMenu:SetMenuOffset(x, y)
+    self.Position = vector2(x, y)
     if self:Visible() then
-        ScaleformUI.Scaleforms._ui:CallFunction("SET_MENU_OFFSET", x,y)
+    local safezone = (1.0 - math.round(GetSafeZoneSize(), 2)) * 100 * 0.005
+    local rightAlign = self.menuAlignment == MenuAlignment.RIGHT
+    local glareX = 0.45 + safezone
+
+    local pos1080 = ConvertScaleformCoordsToResolutionCoords(x, y)
+    local screenCoords = ConvertResolutionCoordsToScreenCoords(pos1080.x, pos1080.y)
+    self._glarePos = vector2(screenCoords.x + glareX, screenCoords.y + 0.45 + safezone)
+    if rightAlign then
+        glareX = 1.225 - safezone
+        local w, h = GetActualScreenResolution()
+        screenCoords = ConvertResolutionCoordsToScreenCoords(1920 - pos1080.x, pos1080.y)
+        self._glarePos = vector2(screenCoords.x - 1 + glareX, screenCoords.y + 0.45 + safezone)
+    end
+    self._glareSize = { w = 1.0, h = 1.0 }
+    self:SetMenuData(true)
     end
 end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuColorPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuColorPanel.lua
@@ -45,11 +45,9 @@ end
 function UIMenuColorPanel:CurrentSelection(new_value)
     if new_value ~= nil then
         self.value = new_value
-        if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() 
-            and self.ParentItem:SetParentMenu().Pagination:IsItemVisible(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)) then
-            local it = self.ParentItem:SetParentMenu().Pagination:GetScaleformIndex(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem))
-            local van = IndexOf(self.ParentItem.Panels, self)
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_COLOR_PANEL_VALUE", it, van-1, new_value)
+        if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
+            local it = IndexOf(self.ParentMenu.Items, self)
+            self.ParentMenu:SendPanelsToItemScaleform(it, true)
         end
     else
         return self.value

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuColorPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuColorPanel.lua
@@ -46,8 +46,10 @@ function UIMenuColorPanel:CurrentSelection(new_value)
     if new_value ~= nil then
         self.value = new_value
         if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
-            local it = IndexOf(self.ParentMenu.Items, self)
-            self.ParentMenu:SendPanelsToItemScaleform(it, true)
+            local it = IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)
+            self.ParentItem:SetParentMenu():SendPanelsToItemScaleform(it, true)
+            self.OnColorPanelChanged(self.ParentItem, self, self.value)
+            self.ParentItem:SetParentMenu().OnColorPanelChanged(self.ParentItem, self, self.value)
         end
     else
         return self.value

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuGridPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuGridPanel.lua
@@ -47,13 +47,9 @@ end
 function UIMenuGridPanel:CirclePosition(position)
     if position ~= nil then
         self._CirclePosition = position
-        if (self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil) and self.ParentItem:SetParentMenu():Visible() 
-            and self.ParentItem:SetParentMenu().Pagination:IsItemVisible(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)) then
-
-            local it = self.ParentItem:SetParentMenu().Pagination:GetScaleformIndex(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem))
-            local van = IndexOf(self.ParentItem.Panels, self)
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_GRID_PANEL_VALUE_RETURN_VALUE", it, van - 1,
-                position.x, position.y)
+        if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
+            local it = IndexOf(self.ParentMenu.Items, self)
+            self.ParentMenu:SendPanelsToItemScaleform(it, true)
         end
     else
         return self._CirclePosition

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuGridPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuGridPanel.lua
@@ -48,8 +48,10 @@ function UIMenuGridPanel:CirclePosition(position)
     if position ~= nil then
         self._CirclePosition = position
         if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
-            local it = IndexOf(self.ParentMenu.Items, self)
-            self.ParentMenu:SendPanelsToItemScaleform(it, true)
+            local it = IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)
+            self.ParentItem:SetParentMenu():SendPanelsToItemScaleform(it, true)
+            self.OnGridPanelChanged(self.ParentItem, self, self._CirclePosition)
+            self.ParentItem:SetParentMenu().OnGridPanelChanged(self.ParentItem, self, self._CirclePosition)
         end
     else
         return self._CirclePosition

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuPercentagePanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuPercentagePanel.lua
@@ -33,8 +33,10 @@ function UIMenuPercentagePanel:Percentage(value)
     if value ~= nil then
         self._percentage = value
         if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
-            local it = IndexOf(self.ParentMenu.Items, self)
-            self.ParentMenu:SendPanelsToItemScaleform(it, true)
+            local it = IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)
+            self.ParentItem:SetParentMenu():SendPanelsToItemScaleform(it, true)
+            self.OnPercentagePanelChanged(self.ParentItem, self, self._percentage)
+            self.ParentItem:SetParentMenu().OnPercentagePanelChange(self.ParentItem, self, self._percentage)
         end
     else
         return self._percentage

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuPercentagePanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuPercentagePanel.lua
@@ -32,11 +32,9 @@ end
 function UIMenuPercentagePanel:Percentage(value)
     if value ~= nil then
         self._percentage = value
-        if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() 
-            and self.ParentItem:SetParentMenu().Pagination:IsItemVisible(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)) then
-            local it = self.ParentItem:SetParentMenu().Pagination:GetScaleformIndex(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem))
-            local van = IndexOf(self.ParentItem.Panels, self)
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_PERCENT_PANEL_RETURN_VALUE", it, van-1, value)
+        if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
+            local it = IndexOf(self.ParentMenu.Items, self)
+            self.ParentMenu:SendPanelsToItemScaleform(it, true)
         end
     else
         return self._percentage

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuStatisticsPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuStatisticsPanel.lua
@@ -37,7 +37,7 @@ function UIMenuStatisticsPanel:AddStatistic(name, value) -- required
         end
         table.insert(self.Items, { ['name'] = name, ['value'] = value })
         if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
-            local it = IndexOf(self.ParentItem:SetParentMenu().Items, self)
+            local it = IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)
             self.ParentItem:SetParentMenu():SendPanelsToItemScaleform(it, true)
         end
     end
@@ -70,7 +70,7 @@ function UIMenuStatisticsPanel:UpdateStatistic(index, value)
         end
         self.Items[index].value = value
         if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
-            local it = IndexOf(self.ParentItem:SetParentMenu().Items, self)
+            local it = IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)
             self.ParentItem:SetParentMenu():SendPanelsToItemScaleform(it, true)
         end
     end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuStatisticsPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuStatisticsPanel.lua
@@ -36,12 +36,9 @@ function UIMenuStatisticsPanel:AddStatistic(name, value) -- required
             value = 0
         end
         table.insert(self.Items, { ['name'] = name, ['value'] = value })
-        if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() 
-            and self.ParentItem:SetParentMenu().Pagination:IsItemVisible(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)) then
-
-            local it = self.ParentItem:SetParentMenu().Pagination:GetScaleformIndex(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem))
-            local van = IndexOf(self.ParentItem.Panels, self)
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_STATISTIC_TO_PANEL", it, van-1, name, value)
+        if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
+            local it = IndexOf(self.ParentMenu.Items, self)
+            self.ParentMenu:SendPanelsToItemScaleform(it, true)
         end
     end
 end
@@ -72,11 +69,9 @@ function UIMenuStatisticsPanel:UpdateStatistic(index, value)
             value = 0
         end
         self.Items[index].value = value
-        if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible()
-            and self.ParentItem:SetParentMenu().Pagination:IsItemVisible(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)) then
-            local it = self.ParentItem:SetParentMenu().Pagination:GetScaleformIndex(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem))
-            local pan = IndexOf(self.ParentItem.Panels, self)
-            ScaleformUI.Scaleforms._ui:CallFunction("SET_PANEL_STATS_ITEM_VALUE", it, pan - 1, index - 1, value)
+        if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
+            local it = IndexOf(self.ParentMenu.Items, self)
+            self.ParentMenu:SendPanelsToItemScaleform(it, true)
         end
     end
 end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuStatisticsPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuStatisticsPanel.lua
@@ -37,8 +37,8 @@ function UIMenuStatisticsPanel:AddStatistic(name, value) -- required
         end
         table.insert(self.Items, { ['name'] = name, ['value'] = value })
         if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
-            local it = IndexOf(self.ParentMenu.Items, self)
-            self.ParentMenu:SendPanelsToItemScaleform(it, true)
+            local it = IndexOf(self.ParentItem:SetParentMenu().Items, self)
+            self.ParentItem:SetParentMenu():SendPanelsToItemScaleform(it, true)
         end
     end
 end
@@ -70,8 +70,8 @@ function UIMenuStatisticsPanel:UpdateStatistic(index, value)
         end
         self.Items[index].value = value
         if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
-            local it = IndexOf(self.ParentMenu.Items, self)
-            self.ParentMenu:SendPanelsToItemScaleform(it, true)
+            local it = IndexOf(self.ParentItem:SetParentMenu().Items, self)
+            self.ParentItem:SetParentMenu():SendPanelsToItemScaleform(it, true)
         end
     end
 end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuVehicleColourPickerPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuVehicleColourPickerPanel.lua
@@ -43,9 +43,8 @@ function UIMenuVehicleColourPickerPanel:Value(val)
 end
 
 function UIMenuVehicleColourPickerPanel:_setValue(val)
-    if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() 
-    and self.ParentItem:SetParentMenu().Pagination:IsItemVisible(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)) then
-        local it = self.ParentItem:SetParentMenu().Pagination:GetScaleformIndex(IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem))
+    if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
         local van = IndexOf(self.ParentItem.Panels, self)
         ScaleformUI.Scaleforms._ui:CallFunction("SET_COLOR_PICKER_PANEL_VALUE", it, van-1, val)
     end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuVehicleColourPickerPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/panels/UIMenuVehicleColourPickerPanel.lua
@@ -44,9 +44,8 @@ end
 
 function UIMenuVehicleColourPickerPanel:_setValue(val)
     if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
-        local it = IndexOf(self.ParentMenu.Items, self)
-        local van = IndexOf(self.ParentItem.Panels, self)
-        ScaleformUI.Scaleforms._ui:CallFunction("SET_COLOR_PICKER_PANEL_VALUE", it, van-1, val)
+        local it = IndexOf(self.ParentItem:SetParentMenu().Items, self.ParentItem)
+        self.ParentItem:SetParentMenu():SendPanelsToItemScaleform(it, true)
     end
 end
 

--- a/ScaleformUI_Lua/src/Menus/UIMenu/sidepanels/UIMissionDetailsPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/sidepanels/UIMissionDetailsPanel.lua
@@ -41,7 +41,7 @@ end
 
 function UIMissionDetailsPanel:UpdatePanelTitle(title)
     self.Title = title
-    if self.ParentItem ~= nil and self.ParentItem.ParentMenu ~= nil and self.ParentItem.ParentMenu:Visible() then
+    if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
         local it = IndexOf(self.ParentMenu.Items, self)
         self.ParentMenu:SendSidePanelToScaleform(it, true)
     end
@@ -51,7 +51,7 @@ function UIMissionDetailsPanel:UpdatePanelPicture(txd, txn)
     self.TextureDict = txd
     self.TextureName = txn
 
-    if self.ParentItem ~= nil and self.ParentItem.ParentMenu ~= nil and self.ParentItem.ParentMenu:Visible() then
+    if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
         local it = IndexOf(self.ParentMenu.Items, self)
         self.ParentMenu:SendSidePanelToScaleform(it, true)
     end
@@ -59,7 +59,7 @@ end
 
 function UIMissionDetailsPanel:AddItem(newitem)
     self.Items[#self.Items + 1] = newitem
-    if self.ParentItem ~= nil and self.ParentItem.ParentMenu ~= nil and self.ParentItem.ParentMenu:Visible() then
+    if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
         local it = IndexOf(self.ParentMenu.Items, self)
         self.ParentMenu:SendSidePanelToScaleform(it, true)
     end
@@ -67,7 +67,7 @@ end
 
 function UIMissionDetailsPanel:RemoveItemAt(index)
     table.remove(self.Items, index)
-    if self.ParentItem ~= nil and self.ParentItem.ParentMenu ~= nil and self.ParentItem.ParentMenu:Visible() then
+    if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
         local it = IndexOf(self.ParentMenu.Items, self)
         self.ParentMenu:SendSidePanelToScaleform(it, true)
     end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/sidepanels/UIMissionDetailsPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/sidepanels/UIMissionDetailsPanel.lua
@@ -41,10 +41,9 @@ end
 
 function UIMissionDetailsPanel:UpdatePanelTitle(title)
     self.Title = title
-
-    if self.ParentItem ~= nil then
-        local item = IndexOf(self.ParentItem.Base.ParentMenu.Items, self.ParentItem) - 1
-        ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_SIDE_PANEL_TITLE", item, title)
+    if self.ParentItem ~= nil and self.ParentItem.ParentMenu ~= nil and self.ParentItem.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it, true)
     end
 end
 
@@ -52,26 +51,24 @@ function UIMissionDetailsPanel:UpdatePanelPicture(txd, txn)
     self.TextureDict = txd
     self.TextureName = txn
 
-    if self.ParentItem ~= nil then
-        local item = IndexOf(self.ParentItem.Base.ParentMenu.Items, self.ParentItem) - 1
-        ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_MISSION_DETAILS_PANEL_IMG", item, txd, txn)
+    if self.ParentItem ~= nil and self.ParentItem.ParentMenu ~= nil and self.ParentItem.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it, true)
     end
 end
 
 function UIMissionDetailsPanel:AddItem(newitem)
     self.Items[#self.Items + 1] = newitem
-    if self.ParentItem ~= nil then
-        local item = IndexOf(self.ParentItem.Base.ParentMenu.Items, self.ParentItem) - 1
-        ScaleformUI.Scaleforms._ui:CallFunction("ADD_MISSION_DETAILS_DESC_ITEM", item, newitem.Type,
-            newitem.TextLeft, newitem.TextRight, newitem.Icon, newitem.IconColor, newitem.Tick, newitem._labelFont.FontName, newitem._labelFont.FontID,
-            newitem._rightLabelFont.FontName, newitem._rightLabelFont.FontID)
+    if self.ParentItem ~= nil and self.ParentItem.ParentMenu ~= nil and self.ParentItem.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it, true)
     end
 end
 
 function UIMissionDetailsPanel:RemoveItemAt(index)
     table.remove(self.Items, index)
-    if self.ParentItem ~= nil then
-        local item = IndexOf(self.ParentItem.Base.ParentMenu.Items, self.ParentItem) - 1
-        ScaleformUI.Scaleforms._ui:CallFunction("REMOVE_MISSION_DETAILS_DESC_ITEM", item, index - 1)
+    if self.ParentItem ~= nil and self.ParentItem.ParentMenu ~= nil and self.ParentItem.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it, true)
     end
 end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/sidepanels/UIVehicleColorPickerPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/sidepanels/UIVehicleColorPickerPanel.lua
@@ -27,7 +27,7 @@ function UIVehicleColorPickerPanel.New(side, title, color)
 end
 
 function UIVehicleColorPickerPanel:SetParentItem(Item) -- required
-    if Item() ~= nil then
+    if Item ~= nil then
         self.ParentItem = Item
     else
         return self.ParentItem

--- a/ScaleformUI_Lua/src/Menus/UIMenu/sidepanels/UIVehicleColorPickerPanel.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/sidepanels/UIVehicleColorPickerPanel.lua
@@ -36,9 +36,9 @@ end
 
 function UIVehicleColorPickerPanel:UpdatePanelTitle(title)
     self.Title = title
-    if self.ParentItem ~= nil and self.ParentItem:SetParentMenu() ~= nil and self.ParentItem:SetParentMenu():Visible() then
-        local item = IndexOf(self.ParentItem.Base.ParentMenu.Items, self.ParentItem) - 1
-        ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_SIDE_PANEL_TITLE", item, title)
+    if self.ParentItem ~= nil and self.ParentItem.ParentMenu ~= nil and self.ParentItem.ParentMenu:Visible() then
+        local it = IndexOf(self.ParentMenu.Items, self)
+        self.ParentMenu:SendSidePanelToScaleform(it, true)
     end
 end
 

--- a/ScaleformUI_Lua/src/Menus/UIMenu/windows/UIMenuDetailsWindow.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/windows/UIMenuDetailsWindow.lua
@@ -15,7 +15,7 @@ function UIMenuDetailsWindow.New(...)
             DetailBottom = args[3],
             StatWheelEnabled = false,
             DetailLeft = args[4] or {
-                Txd = "",
+                Txd = "statWheel",
                 Txn = "",
                 Pos = vector2(0, 0),
                 Size = vector2(0, 0),
@@ -57,33 +57,21 @@ function UIMenuDetailsWindow:UpdateLabels(top, mid, bot, leftDetail)
     self.DetailMid = mid
     self.DetailBottom = bot
     self.DetailLeft = leftDetail or {
-        Txd = "",
+        Txd = "statWheel",
         Txn = "",
         Pos = vector2(0, 0),
         Size = vector2(0, 0),
-    }
-
-    if self.ParentMenu ~= nil then
-        local wid = IndexOf(self.ParentMenu.Windows, self) - 1
-        if self.StatWheelEnabled then
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_DETAILS_WINDOW_VALUES", wid, self.DetailBottom,
-                self.DetailMid, self.DetailTop, "statWheel")
-        else
-            ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_DETAILS_WINDOW_VALUES", wid, self.DetailBottom,
-                self.DetailMid, self.DetailTop, self.DetailLeft.Txd, self.DetailLeft.Txn, self.DetailLeft.Pos.x,
-                self.DetailLeft.Pos.y, self.DetailLeft.Size.x, self.DetailLeft.Size.y)
-        end
+}
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        self.ParentMenu:SetWindows(true)
     end
 end
 
 function UIMenuDetailsWindow:AddStatsListToWheel(stats)
     if self.StatWheelEnabled then
         self.DetailStats = stats
-        if self.ParentMenu ~= nil then
-            local wid = IndexOf(self.ParentMenu.Windows, self) - 1
-            for key, value in pairs(self.DetailStats) do
-                ScaleformUI.Scaleforms._ui:CallFunction("ADD_STATS_DETAILS_WINDOW_STATWHEEL", wid, value.Percentage, value.HudColor)
-            end
+        if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+            self.ParentMenu:SetWindows(true)
         end
     end
 end
@@ -91,20 +79,16 @@ end
 function UIMenuDetailsWindow:AddStatSingleToWheel(stat)
     if self.StatWheelEnabled then
         self.DetailStats[#self.DetailStats + 1] = stat
-        if self.ParentMenu ~= nil then
-            local wid = IndexOf(self.ParentMenu.Windows, self) - 1
-            ScaleformUI.Scaleforms._ui:CallFunction("ADD_STATS_DETAILS_WINDOW_STATWHEEL", wid, stat.Percentage, stat.HudColor)
+        if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+            self.ParentMenu:SetWindows(true)
         end
     end
 end
 
 function UIMenuDetailsWindow:UpdateStatsToWheel()
     if self.StatWheelEnabled then
-        if self.ParentMenu ~= nil then
-            local wid = IndexOf(self.ParentMenu.Windows, self) - 1
-            for key, value in pairs(self.DetailStats) do
-                ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_STATS_DETAILS_WINDOW_STATWHEEL", wid, key - 1, value.Percentage, value.HudColor)
-            end
+        if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+            self.ParentMenu:SetWindows(true)
         end
     end
 end

--- a/ScaleformUI_Lua/src/Menus/UIMenu/windows/UIMenuHeritageWindow.lua
+++ b/ScaleformUI_Lua/src/Menus/UIMenu/windows/UIMenuHeritageWindow.lua
@@ -42,6 +42,7 @@ function UIMenuHeritageWindow:Index(Mom, Dad)
     self.Mom = Mom - 1
     self.Dad = Dad - 1
 
-    local wid = IndexOf(self.ParentMenu.Windows, self) - 1
-    ScaleformUI.Scaleforms._ui:CallFunction("UPDATE_HERITAGE_WINDOW", wid, self.Mom, self.Dad)
+    if self.ParentMenu ~= nil and self.ParentMenu:Visible() then
+        self.ParentMenu:SetWindows(true)
+    end
 end


### PR DESCRIPTION
- Completely rewrote the main Scaleform movie.
- Fixed Glare position across resolutions (16:10 is completely bad on fivem for certain ui elements)
- **__Code Breaking__**: 
  - Removed fading time parameter in Lua/C# `UIMenu` constructors
  - Removed TextColor and HighlightedTextColor parameters in Items (unused and legacy)
- Disabled all animations in menu.
- Rewrote menu building system.
- Rewrote menu and components updating process.
- Modularized Scaleform movie to give the R* feeling we didn't know we were missing and didn't know we needed.
- Fixed menu switching inheritance, it's now almost instant.
- Performances increased up to by 40% across ScRTs.
- All the exposed API has not been edited to maintain compatibility with the new update, marking as obsolete all the removed features.
- UIMenuItem is now dynamic.
- UIMenuListItem supports now virtually infinite list elements
- I'm sure i forgot something.. 😛

All UIMenus are now updated. 
Next update will bring a totally renewed and rewrote PauseMenu.